### PR TITLE
chore: upgrade Hyperdrive to 11.5.3, fix blob-store tests, fix hyperdrive blob namespace

### DIFF
--- a/lib/blob-store/index.js
+++ b/lib/blob-store/index.js
@@ -266,7 +266,7 @@ class PretendCorestore {
       )
     } else if (opts.name === 'db') {
       return this.#coreManager.getWriterCore('blobIndex').core
-    } else if (opts.name === 'blobs') {
+    } else if (opts.name.includes('blobs')) {
       return this.#coreManager.getWriterCore('blob').core
     } else {
       throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fastify-plugin": "^4.5.0",
         "hypercore": "^10.9.0",
         "hypercore-crypto": "^3.3.1",
-        "hyperdrive": "github:holepunchto/hyperdrive#3db28f3",
+        "hyperdrive": "^11.5.3",
         "hyperswarm": "^4.4.1",
         "magic-bytes.js": "^1.0.14",
         "mapeo-schema": "github:digidem/mapeo-schema#protobufsTypescript",
@@ -2569,6 +2569,11 @@
         "sodium-universal": "^4.0.0"
       }
     },
+    "node_modules/hypercore-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hypercore-errors/-/hypercore-errors-1.0.0.tgz",
+      "integrity": "sha512-lYGykNANCfQdvsDNfbAV2RJCu4ITXxFrq3Gf0nDRZEwH0po/rjZdjTLYhzH1mJZNc6toNaD5URBpwqeD/Ug4JA=="
+    },
     "node_modules/hyperdht": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.5.3.tgz",
@@ -2595,12 +2600,13 @@
       }
     },
     "node_modules/hyperdrive": {
-      "version": "11.4.0",
-      "resolved": "git+ssh://git@github.com/holepunchto/hyperdrive.git#3db28f30409ca02284b9499fdc39f3c02700f4be",
-      "license": "Apache-2.0",
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-11.5.3.tgz",
+      "integrity": "sha512-0542G6n9eAXK/+fl6bs+9rvxCrL/dQo9mZsbY+BFSCD3S6ymBlaVnjOCuQdNflYBOHFVNnbBYdDvZ9meInv+tw==",
       "dependencies": {
         "hyperbee": "^2.11.1",
         "hyperblobs": "^2.3.0",
+        "hypercore-errors": "^1.0.0",
         "is-options": "^1.0.2",
         "mirror-drive": "^1.2.0",
         "ready-resource": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "fastify-plugin": "^4.5.0",
     "hypercore": "^10.9.0",
     "hypercore-crypto": "^3.3.1",
-    "hyperdrive": "github:holepunchto/hyperdrive#3db28f3",
+    "hyperdrive": "^11.5.3",
     "hyperswarm": "^4.4.1",
     "magic-bytes.js": "^1.0.14",
     "mapeo-schema": "github:digidem/mapeo-schema#protobufsTypescript",

--- a/tests/blob-store/live-download.js
+++ b/tests/blob-store/live-download.js
@@ -70,14 +70,15 @@ test('sparse live download', async t => {
 
   t.alike(await drive2.get('photo/original/one'), buf1)
   t.alike(await drive2.get('photo/original/two'), buf2)
-  t.is(
-    await drive2.get('video/original/one', { wait: false }),
-    null,
+
+  await t.exception(
+    drive2.get('video/original/one', { wait: false }),
+    /BLOCK_NOT_AVAILABLE/,
     'Block not available'
   )
-  t.is(
-    await drive2.get('video/original/two', { wait: false }),
-    null,
+  await t.exception(
+    drive2.get('video/original/two', { wait: false }),
+    /BLOCK_NOT_AVAILABLE/,
     'Block not available'
   )
 })
@@ -121,7 +122,11 @@ test('Abort download (next event loop)', async t => {
     error: null,
     status: 'aborted'
   })
-  t.is(await drive2.get('/foo', { wait: false }), null, 'Block not available')
+  await t.exception(
+    drive2.get('/foo', { wait: false }),
+    /Block not available locally/,
+    'Block not available locally'
+  )
 })
 
 test('Abort download (after initial download)', async t => {
@@ -146,9 +151,9 @@ test('Abort download (after initial download)', async t => {
   await once(stream, 'close')
 
   t.alike(await drive2.get('/one'), buf1, 'First blob is downloaded')
-  t.is(
-    await drive2.get('/two', { wait: false }),
-    null,
+  await t.exception(
+    drive2.get('/two', { wait: false }),
+    /BLOCK_NOT_AVAILABLE/,
     'Second blob is not downloaded'
   )
 })


### PR DESCRIPTION
This pr upgrades the hyperdrive package to latest and fixes a couple small errors:
- blobs are now always [prefixed by the internal hyperbee's core id](https://github.com/holepunchto/hyperdrive/pull/355/files)
- A few tests needed to check for a thrown exception rather than a null return value

Closes #147