### PR TITLE
chore: check npm lockfile version does not change

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,10 +1,13 @@
-name: npm lockfile
+name: Check Lockfile
 on: pull_request
 jobs:
   lockfile:
+    name: Lockfile check
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4
       - name: Check package-lock.json version has not been changed
         uses: mansona/npm-lockfile-version@v1
+        with:
+          version: 3


### PR DESCRIPTION
running `npm install` with a different version of npm will result in
the lockfileVersion being changes in package-lock.json
This checks for that change in PRs, since we don't want that to happen.