### PR TITLE
chore: remove unused `LocalDiscovery` members

### DIFF
--- a/src/discovery/local-discovery.js
+++ b/src/discovery/local-discovery.js
@@ -66,10 +66,6 @@ export class LocalDiscovery extends TypedEmitter {
     })
   }
 
-  get publicKey() {
-    return this.#identityKeypair.publicKey
-  }
-
   /** @returns {Promise<{ name: string, port: number }>} */
   async start() {
     await this.#sm.start()
@@ -254,10 +250,6 @@ export class LocalDiscovery extends TypedEmitter {
     // No 'error' listeners attached to `conn` at this point, it's up to the
     // consumer to attach an 'error' listener to avoid uncaught errors.
     this.emit('connection', conn)
-  }
-
-  get connections() {
-    return this.#noiseConnections.values()
   }
 
   /**

--- a/tests/discovery/local-discovery.js
+++ b/tests/discovery/local-discovery.js
@@ -135,7 +135,7 @@ async function testMultiple(t, { period, nPeers = 20 }) {
   for (let i = 0; i < nPeers; i++) {
     const identityKeypair = new KeyManager(randomBytes(16)).getIdentityKeypair()
     const discovery = new LocalDiscovery({ identityKeypair })
-    const peerId = keyToPublicId(discovery.publicKey)
+    const peerId = keyToPublicId(identityKeypair.publicKey)
     peersById.set(peerId, discovery)
     /** @type {OpenedNoiseStream[]} */
     const conns = []


### PR DESCRIPTION
This change should have no functionality impact.

`LocalDiscovery.prototype.publicKey` and `.connections` were unused, so we can remove them. (There was technically a test that used one of them, but that was easy to change.)