### PR TITLE
chore: use more exact type in socket error handler

### DIFF
--- a/src/discovery/local-discovery.js
+++ b/src/discovery/local-discovery.js
@@ -113,9 +113,9 @@ export class LocalDiscovery extends TypedEmitter {
     socket.off('error', this.#handleSocketError)
     socket.on('error', onSocketError)
 
-    /** @param {any} e */
+    /** @param {Error} e */
     function onSocketError(e) {
-      if (e.code === 'EPIPE') {
+      if ('code' in e && e.code === 'EPIPE') {
         socket.destroy()
         if (secretStream) {
           secretStream.destroy()


### PR DESCRIPTION
*This change should have no impact on functionality.*

Our local TCP socket error handler was typed with an `any` parameter but could easily be typed with an `Error` instead. This changes that.