### PR TITLE
chore: use `Primitive` type from type-fest

### DIFF
--- a/src/lib/hashmap.js
+++ b/src/lib/hashmap.js
@@ -1,4 +1,4 @@
-/** @typedef {string | number | bigint | boolean | undefined | symbol | null} Primitive */
+/** @import { Primitive } from 'type-fest' */
 
 /**
  * `Map` uses same-value-zero equality for keys, which makes it more difficult


### PR DESCRIPTION
This types-only change removes a custom `Primitive` type in favor of type-fest's.

We defined them the same way so it shouldn't make a difference.

*I plan to yolo-merge this when CI passes.*