### PR TITLE
chore: semver on release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,14 @@ on:
       semver:
         description: 'The semver to use'
         required: true
-        default: 'prerelease'
+        default: 'patch'
         type: choice
         options:
           # - auto
-          # - patch
-          # - minor
-          # - major
-          - prerelease
+          - patch
+          - minor
+          - major
+          # - prerelease
           # - prepatch
           # - preminor
           # - premajor
@@ -53,10 +53,10 @@ jobs:
           sync-semver-tags: true
           access: 'public'
           # This prefix is added before the prerelease number, e.g. `v3.0.0-alpha.0`
-          prerelease-prefix: 'alpha'
+          # prerelease-prefix: 'alpha'
           semver: ${{ github.event.inputs.semver }}
           # Prereleases are published under the `alpha` npm dist-tag
-          npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'alpha' || 'latest' }}
+          # npm-tag: ${{ startsWith(github.event.inputs.semver, 'pre') && 'alpha' || 'latest' }}
           # Don't notify linked issues
           notify-linked-issues: false
           # optional: set this secret in your repo config for publishing to NPM


### PR DESCRIPTION
Since the idea is to follow semver, I've went ahead and only allowed (and uncommented) `patch`, `minor` and `version` on semver options. We may disagree with this and still have a prerelease (but I think we may not want this). 
Also I commented some traces of `prerelease` related to naming the release on github and npm. If approve, I'll remove those commented lines