### PR TITLE
chore: update authors before release of 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,11 @@
     "url": "git+https://github.com/digidem/mapeo-core.git"
   },
   "authors": [
-    "Karissa McKelvey",
-    "Gregor MacLennan",
-    "noffle"
+    "Andrew Chou <achou@awana.digital>",
+    "Evan Hahn <ehahn@awana.digital>",
+    "Gregor MacLennan <gmaclennan@awana.digital>",
+    "Seth Vincent",
+    "Tomás Ciccola <tciccola@awana.digital>"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This updates the `authors` field of package.json.

To do this, I found 2e08a868f38237fc192101c8aeed4d660918121b, the commit where we reset the repo. Then, I ran this to get the unique authors:

```sh
git log 2e08a868f38237fc192101c8aeed4d660918121b~1.. --format=%an | sort -u
```

I cleaned that up a bit and dumped it here.
