### PR TITLE
build: re-enable prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - patch
           - minor
           - major
-          # - prerelease
+          - prerelease
           # - prepatch
           # - preminor
           # - premajor


### PR DESCRIPTION
I want to make a prerelease version.