### PR TITLE
fix: pin `corestore` dep to exact 6.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "big-sparse-array": "^1.0.3",
         "bogon": "^1.1.0",
         "compact-encoding": "^2.12.0",
-        "corestore": "^6.8.4",
+        "corestore": "6.8.4",
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "drizzle-orm": "^0.30.8",
@@ -2133,7 +2133,8 @@
     },
     "node_modules/corestore": {
       "version": "6.8.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-6.8.4.tgz",
+      "integrity": "sha512-rJUn1bK2Id18mxZSb64fKGCSsbbBAvPUkSZVzsLB4Nnwhf3pkwxt/JjBvKHtsrvRyPAu9xtxUdUk1cSQ1JnOPw==",
       "dependencies": {
         "b4a": "^1.3.1",
         "hypercore": "^10.12.0",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "yazl": "^2.5.1"
   },
   "dependencies": {
+    "@comapeo/schema": "1.0.0",
     "@digidem/types": "^2.3.0",
     "@electron/asar": "^3.2.8",
     "@fastify/error": "^3.4.1",
@@ -158,7 +159,6 @@
     "@fastify/type-provider-typebox": "^4.0.0",
     "@hyperswarm/secret-stream": "^6.1.2",
     "@mapeo/crypto": "1.0.0-alpha.10",
-    "@comapeo/schema": "1.0.0",
     "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
     "@sinclair/typebox": "^0.29.6",
     "b4a": "^1.6.3",
@@ -167,7 +167,7 @@
     "big-sparse-array": "^1.0.3",
     "bogon": "^1.1.0",
     "compact-encoding": "^2.12.0",
-    "corestore": "^6.8.4",
+    "corestore": "6.8.4",
     "debug": "^4.3.4",
     "dot-prop": "^9.0.0",
     "drizzle-orm": "^0.30.8",


### PR DESCRIPTION
This is the cause of bugs in the v1.0.0 release candidate. The `corestore` dependency should have been pinned to the exact version that we are testing here (v6.8.4), but it was not.

The mobile app had already been using `corestore@6.15.9`, which had changed the hypercore dep to `hypercore@10.29.0`. This appeared to still work, to some extent. Commit https://github.com/digidem/comapeo-mobile/commit/e06a7e4554f1ac8f47f5bb407d328bf37f8919cb included a `src/backend/package-lock.json` change that changed the corestore dep to `corestore@6.18.4` and its subdep to `hypercore@10.37.22`.

Unfortunately we rely on hypercore internals, and in addition hypercore is not completely stable across minor versions, so changes to the hypercore version break things. We have thorough tests on comapeo-core to check that all the internals of hypercore that we depend on are tested and working, however the omission of pinning corestore resulted in a different version of hypercore being used in the mobile app.

