### PR TITLE
chore: integrate npm-lockfile-changes action

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -21,8 +21,14 @@ jobs:
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.LOCKFILE_BOT_APP_ID }}
+          private-key: ${{ secrets.LOCKFILE_BOT_PRIVATE_KEY }}
       - name: NPM Lockfile Changes
         # The original doesn't support v3 lockfiles so we use a fork that adds support for them
         uses: rvanvelzen/npm-lockfile-changes@6fded38b5a054f5ab49efd6850668e796f780604
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,5 +1,9 @@
 name: Check Lockfile
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'package-lock.json'
+
 jobs:
   lockfile_version:
     name: Lockfile version check

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/checkout@v4
       - name: NPM Lockfile Changes
         # The original doesn't support v3 lockfiles so we use a fork that adds support for them
-        uses: rvanvelzen/npm-lockfile-changes@main
+        uses: rvanvelzen/npm-lockfile-changes@6fded38b5a054f5ab49efd6850668e796f780604
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4
       - name: NPM Lockfile Changes
+        # The original doesn't support v3 lockfiles so we use a fork that adds support for them
         uses: rvanvelzen/npm-lockfile-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -14,13 +14,10 @@ jobs:
   lockfile_changes:
     name: Lockfile changes check
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4
       - name: NPM Lockfile Changes
-        uses: codepunkt/npm-lockfile-changes@v1.0.0
+        uses: rvanvelzen/npm-lockfile-changes@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -14,6 +14,9 @@ jobs:
   lockfile_changes:
     name: Lockfile changes check
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v4

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,8 +1,8 @@
 name: Check Lockfile
 on: pull_request
 jobs:
-  lockfile:
-    name: Lockfile check
+  lockfile_version:
+    name: Lockfile version check
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repo
@@ -11,3 +11,13 @@ jobs:
         uses: mansona/npm-lockfile-version@v1
         with:
           version: 3
+  lockfile_changes:
+    name: Lockfile changes check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v4
+      - name: NPM Lockfile Changes
+        uses: codepunkt/npm-lockfile-changes@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses a fork (https://github.com/rvanvelzen/npm-lockfile-changes) of the original action (https://github.com/codepunkt/npm-lockfile-changes) because the original does not seem to work with v3 lockfiles.

Uses the action's default values for inputs for now (https://github.com/marketplace/actions/npm-lockfile-changes#-inputs)

Also omits the `permissions` configuration since we don't use dependabot (https://github.com/marketplace/actions/npm-lockfile-changes#the-action-fails-on-the-dependabot-pull-requests). My understanding is that we don't need to specify as a result, but could be wrong.

Out of scope, but also updated this workflow to only run when the pull request changes the `package-lock.json` file, as opposed to anytime a pull request is opened. Happy to revert if not desired.