### PR TITLE
chore: remove unnecessary helper from namespace sync state

### DIFF
--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -62,7 +62,7 @@ export class NamespaceSyncState {
     const state = {
       dataToSync: false,
       coreCount: this.#coreCount,
-      localState: createState(),
+      localState: { want: 0, have: 0, wanted: 0 },
       remoteStates: {},
     }
     for (const css of this.#coreStates.values()) {
@@ -130,28 +130,6 @@ export class NamespaceSyncState {
       this.#coreStates.set(discoveryId, coreState)
     }
     return coreState
-  }
-}
-
-/**
- * @overload
- * @returns {SyncState['localState']}
- */
-
-/**
- * @overload
- * @param {import('./core-sync-state.js').PeerNamespaceState['status']} status
- * @returns {import('./core-sync-state.js').PeerNamespaceState}
- */
-
-/**
- * @param {import('./core-sync-state.js').PeerNamespaceState['status']} [status]
- */
-export function createState(status) {
-  if (status) {
-    return { want: 0, have: 0, wanted: 0, status }
-  } else {
-    return { want: 0, have: 0, wanted: 0 }
   }
 }
 


### PR DESCRIPTION
*This change should have no user impact.*

`createState()` is never called with an argument, so we can remove the function and inline it.
