### PR TITLE
chore: remove unused property from translation API

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -345,7 +345,6 @@ export class MapeoProject extends TypedEmitter {
 
     this.#translationApi = new TranslationApi({
       dataType: this.#dataTypes.translation,
-      table: translationTable,
     })
 
     ///////// 4. Replicate local peers automatically

--- a/src/translation-api.js
+++ b/src/translation-api.js
@@ -14,7 +14,6 @@ export default class TranslationApi {
    * Set<import('@comapeo/schema/dist/types.js').SchemaName>>} */
   #translatedLanguageCodeToSchemaNames = new Map()
   #dataType
-  #table
   #indexPromise
 
   /**
@@ -26,11 +25,9 @@ export default class TranslationApi {
    *   Translation,
    *   TranslationValue
    * >}  opts.dataType
-   * @param {typeof import('./schema/project.js').translationTable} opts.table
    */
-  constructor({ dataType, table }) {
+  constructor({ dataType }) {
     this.#dataType = dataType
-    this.#table = table
     this.#indexPromise = this.#dataType
       .getMany()
       .then((docs) => {

--- a/tests/data-type.js
+++ b/tests/data-type.js
@@ -358,10 +358,7 @@ async function testenv(opts = {}) {
     },
   })
 
-  const translationApi = new TranslationApi({
-    dataType: translationDataType,
-    table: translationTable,
-  })
+  const translationApi = new TranslationApi({ dataType: translationDataType })
 
   const dataType = new DataType({
     dataStore,

--- a/tests/translation-api.js
+++ b/tests/translation-api.js
@@ -151,8 +151,5 @@ function setup() {
     },
   })
 
-  return new TranslationApi({
-    dataType,
-    table,
-  })
+  return new TranslationApi({ dataType })
 }


### PR DESCRIPTION
`TranslationApi` was storing a property called `#table` which was never used. This removes it.