### PR TITLE
chore: only attempt to run release workflow when merging PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,11 @@ on:
           # - premajor
   pull_request:
     types: [closed]
+    branches: [main]
 
 jobs:
   release:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Does a couple of things:

- Makes sure the pull request is targeting the main branch. Not sure if there are cases where we want this thing to run when that isn't the case

- Makes sure that the pull request is actually merged. Before, the workflow was being run when closing a pull request (and not merging), which adds more noise than necessary