### PR TITLE
build: move doc building into same step as release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,19 +34,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/checkout@v4
-      - name: Set git user
-        uses: fregante/setup-git-user@v1
-      - name: Generate Api docs
-        run: |
-          npm ci
-          npm run doc
-      - name: Push updated markdown docs
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'docs: update API docs'
-          file_pattern: 'docs/api/md/*'
-          push_options: --force
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
           commit-message: 'Release {version}'
@@ -63,3 +50,4 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
             npm ci
+            npm run doc


### PR DESCRIPTION
I *think* this will fix the errors we're seeing on `release` CI.

See [the optic-release docs][0].

[0]: https://github.com/nearform-actions/optic-release-automation-action/blob/2bdd6c56fa196bd0c8f4f5a4374fc39b3ff78c8a/action.yml#L13-L15