### PR TITLE
fix: close idle connections when stopping FastifyController

### DIFF
--- a/src/fastify-controller.js
+++ b/src/fastify-controller.js
@@ -64,7 +64,13 @@ export class FastifyController {
 
   async #stopServer() {
     const { server } = this.#fastify
-    await promisify(server.close.bind(server))()
+
+    const closePromise = promisify(server.close.bind(server))()
+
+    // We call this after `server.close()` as recommended by the Node docs (see https://nodejs.org/docs/latest-v20.x/api/http.html#servercloseidleconnections)
+    server.closeIdleConnections()
+
+    await closePromise
   }
 
   /**


### PR DESCRIPTION
In Node 18, calling `HTTP.Server.close()` does not close idle connections, which resulted in some undesirable behavior in the server lifecycle in CoMapeo Mobile (see https://github.com/digidem/comapeo-mobile/pull/748 for more context). In Node >=19, closing the server does the equivalent work of of `closeIdleConnections()` internally.

This PR explicitly calls `closeIdleConnections()` when stopping the server, at the guidance of the [Node docs](https://nodejs.org/docs/latest-v20.x/api/http.html#servercloseidleconnections):

> Starting with Node.js 19.0.0, there's no need for calling this method in conjunction with server.close to reap keep-alive connections. Using it won't cause any harm though, and it can be useful to ensure backwards compatibility for libraries and applications that need to support versions older than 19.0.0. Whenever using this in conjunction with server.close, calling this after server.close is recommended as to avoid race conditions where new connections are created between a call to this and a call to server.close.

There's probably an easy way to test this but wasn't immediately sure of how to do it. Happy to add one with some guidance.
