### PR TITLE
chore: add another branch filter for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
           # - premajor
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [main, 'release/**']
 
 jobs:
   release:


### PR DESCRIPTION
Adds a branch filter for any release-related branch so that the workflow runs more precisely.

https://optic.nearform.com/docs/github-action/examples#using-the-branches-filter