### PR TITLE
chore: use consistent `NoiseStream` imports

### DIFF
--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -13,6 +13,7 @@ import {
 import pDefer from 'p-defer'
 import { Logger } from './logger.js'
 import pTimeout, { TimeoutError } from 'p-timeout'
+/** @import NoiseStream from '@hyperswarm/secret-stream' */
 /** @import { OpenedNoiseStream } from './lib/noise-secret-stream-helpers.js' */
 
 // Unique identifier for the mapeo rpc protocol
@@ -329,7 +330,7 @@ export class LocalPeers extends TypedEmitter {
   /**
    * Connect to a peer over an existing NoiseSecretStream
    *
-   * @param {import('./types.js').NoiseStream<any>} stream a NoiseSecretStream from @hyperswarm/secret-stream
+   * @param {NoiseStream<any>} stream
    * @returns {import('./types.js').ReplicationStream}
    */
   connect(stream) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,6 @@ export type HypercorePeer = {
   onrange: (options: { drop: boolean; start: number; length: number }) => void
 }
 
-export { NoiseStream }
 type ProtocolStream = Omit<NoiseStream, 'userData'> & {
   userData: Protomux
 }


### PR DESCRIPTION
This is a types-only change.

We import the `NoiseStream` type in a bunch of places. Typically, we import it from the source: `@hyperswarm/secret-stream`. This fixes one occurrence of a spot where we *didn't* do that, and we exporting it via a types utility file.
