### PR TITLE
test: additional assertions in "blocked from sync" test

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -690,6 +690,17 @@ test('no sync capabilities === no namespaces sync apart from auth', async (t) =>
   )
   const [invitorProject, inviteeProject] = projects
 
+  assert.equal(
+    (await invitorProject.$member.getById(blocked.deviceId)).role.roleId,
+    BLOCKED_ROLE_ID,
+    'invitor sees blocked participant as part of the project'
+  )
+  assert.equal(
+    (await inviteeProject.$member.getById(blocked.deviceId)).role.roleId,
+    BLOCKED_ROLE_ID,
+    'invitee sees blocked participant as part of the project'
+  )
+
   const generatedDocs = (await seedDatabases([inviteeProject])).flat()
   const configDocsCount = generatedDocs.filter(
     (doc) => doc.schemaName !== 'observation'


### PR DESCRIPTION
We test that blocked members shouldn't be able to sync. However, it's possible that this test had false positives if the blocked member was simply missing from the project entirely!

This adds two assertions to make sure that the other members see the blocked one, and that they are indeed blocked.
