### PR TITLE
test: be more exact when waiting for peers

### DIFF
--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -127,17 +127,21 @@ export async function invite({
  */
 export const waitForPeers = (managers, { waitForDeviceInfo = false } = {}) =>
   new Promise((res) => {
-    const expectedCount = managers.length - 1
+    const deviceIds = new Set(managers.map((m) => m.deviceId))
+
     const isDone = () =>
       managers.every((manager) => {
-        const { peers } = manager[kRPC]
-        const connectedPeers = peers.filter(
-          ({ status }) => status === 'connected'
-        )
-        return (
-          connectedPeers.length === expectedCount &&
-          (!waitForDeviceInfo || connectedPeers.every(({ name }) => !!name))
-        )
+        const unconnectedDeviceIds = new Set(deviceIds)
+        unconnectedDeviceIds.delete(manager.deviceId)
+        for (const peer of manager[kRPC].peers) {
+          if (
+            peer.status === 'connected' &&
+            (!waitForDeviceInfo || peer.name)
+          ) {
+            unconnectedDeviceIds.delete(peer.deviceId)
+          }
+        }
+        return unconnectedDeviceIds.size === 0
       })
 
     if (isDone()) {


### PR DESCRIPTION
`waitForPeers`, a test helper, currently checks that the *number* of connected peers is expected. This has two problems:

- If the number of connected peers is *more than needed*, it will never resolve.
- If the *number* of connected peers is correct but the actual peers are different, the promise could resolve prematurely.

This snippet highlights the problem:

```javascript
const managers = await createManagers(3, t)
const [a, b, c] = managers

connectPeers(managers)

await waitForPeers([a, c])
```

I think this is a useful change on its own, but will also make [an upcoming change][0] easier.

[0]: https://github.com/digidem/comapeo-core/pull/865
