### PR TITLE
test: speed up bitfield test slightly

### DIFF
--- a/tests/core-manager.js
+++ b/tests/core-manager.js
@@ -353,12 +353,11 @@ test('sends "haves" bitfields over project creator core replication stream', asy
 
   const cm1Core = cm1.getWriterCore('data').core
   await cm1Core.ready()
-  const batchSize = 4096
   // Create 4 million entries in hypercore - will be at least two have bitfields
+  const batchSize = 4096
+  const block = new Uint8Array([99])
+  const data = Array(batchSize).fill(block)
   for (let i = 0; i < 2 ** 22; i += batchSize) {
-    const data = Array(batchSize)
-      .fill(null)
-      .map(() => 'block')
     await cm1Core.append(data)
   }
 


### PR DESCRIPTION
Speed up the test by about 1 second on my machine by making two changes:

- Only create the blocks once, rather than on every loop.
- Use a byte buffer instead of a string to [skip string-to-buffer encoding][0]

[0]: https://github.com/holepunchto/hypercore/blob/16375ac22e87907b212c03d0e4a8e6b0a38f8c76/index.js#L957-L966
