### PR TITLE
chore: update `@hyperswarm/secret-stream` to 6.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fastify/error": "^3.4.1",
         "@fastify/static": "^7.0.3",
         "@fastify/type-provider-typebox": "^4.0.0",
-        "@hyperswarm/secret-stream": "^6.1.2",
+        "@hyperswarm/secret-stream": "^6.6.3",
         "@mapeo/crypto": "1.0.0-alpha.10",
         "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
         "@sinclair/typebox": "^0.29.6",
@@ -669,8 +669,9 @@
       "dev": true
     },
     "node_modules/@hyperswarm/secret-stream": {
-      "version": "6.1.2",
-      "license": "MIT",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@hyperswarm/secret-stream/-/secret-stream-6.6.3.tgz",
+      "integrity": "sha512-F/EF5KLUqjkTNFof1K5dz57CwrwjSzG0XxZe2X9t/2/mG5iQ28yJIwNcVabkWS1Wk2ZB719piVGKk6YbwkJ0aQ==",
       "dependencies": {
         "b4a": "^1.1.0",
         "hypercore-crypto": "^3.3.1",
@@ -678,7 +679,7 @@
         "noise-handshake": "^3.0.2",
         "sodium-secretstream": "^1.1.0",
         "sodium-universal": "^4.0.0",
-        "streamx": "^2.13.0",
+        "streamx": "^2.14.0",
         "timeout-refresh": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@fastify/error": "^3.4.1",
     "@fastify/static": "^7.0.3",
     "@fastify/type-provider-typebox": "^4.0.0",
-    "@hyperswarm/secret-stream": "^6.1.2",
+    "@hyperswarm/secret-stream": "^6.6.3",
     "@mapeo/crypto": "1.0.0-alpha.10",
     "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
     "@sinclair/typebox": "^0.29.6",


### PR DESCRIPTION
This updates `@hyperswarm/secret-stream` to the latest version.

I think this is a useful change on its own but is also useful as part of our upcoming cloud server work.