### PR TITLE
chore: use `await` instead of `then` in server route

### DIFF
--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -65,9 +65,7 @@ export default async function routes(fastify) {
       },
     },
     async function (req, reply) {
-      const hasExistingProject = await this.comapeo
-        .listProjects()
-        .then((projects) => projects.length > 0)
+      const hasExistingProject = (await this.comapeo.listProjects()).length > 0
 
       if (hasExistingProject) {
         reply.status(400)


### PR DESCRIPTION
This is a minor change. I think it makes sense to use `await` in an async function, rather than using `then` to handle the promise.

(I guess we're `await`ing in either case, but I think this is clearer.)
