### PR TITLE
chore: update `@types/node` to latest 18.x version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "@types/json-schema": "^7.0.11",
         "@types/json-stable-stringify": "^1.0.36",
         "@types/nanobench": "^3.0.0",
-        "@types/node": "^18.19.33",
+        "@types/node": "^18.19.54",
         "@types/sinonjs__fake-timers": "^8.1.2",
         "@types/streamx": "^2.9.5",
         "@types/sub-encoder": "^2.1.0",
@@ -1321,9 +1321,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
-      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "version": "18.19.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.54.tgz",
+      "integrity": "sha512-+BRgt0G5gYjTvdLac9sIeE0iZcJxi4Jc4PV5EUzqi+88jmQLr+fRZdv2tCTV7IHKSGxM6SaLoOXQWWUiLUItMw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@types/json-schema": "^7.0.11",
     "@types/json-stable-stringify": "^1.0.36",
     "@types/nanobench": "^3.0.0",
-    "@types/node": "^18.19.33",
+    "@types/node": "^18.19.54",
     "@types/sinonjs__fake-timers": "^8.1.2",
     "@types/streamx": "^2.9.5",
     "@types/sub-encoder": "^2.1.0",


### PR DESCRIPTION
For reasons unknown to me, `npm run protobuf` was failing due to this being out of date. I assume this was because of our recent TypeScript upgrade, but I did not investigate. In any case, updating fixes it and is a worthwhile change regardless.
