### PR TITLE
chore: change lockfile bot to update comments

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -32,3 +32,4 @@ jobs:
         uses: rvanvelzen/npm-lockfile-changes@6fded38b5a054f5ab49efd6850668e796f780604
         with:
           token: ${{ steps.app-token.outputs.token }}
+          updateComment: true


### PR DESCRIPTION
This proposed change is to the lockfile bot which comments on pull requests with changes to the lockfile. I propose changing the bot config to update the original comment when the PR is updated, rather than creating new comments, in order to reduce "noise" in the PR comment thread. Open to arguments for keeping it as-is with new comments for each commit!
