### PR TITLE
chore: debug logging improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "random-access-file": "^4.0.7",
         "random-access-memory": "^6.2.1",
         "rimraf": "^5.0.5",
+        "supports-color": "^9.4.0",
         "tempy": "^3.1.0",
         "ts-proto": "^1.156.7",
         "typedoc": "^0.26.7",
@@ -1975,6 +1976,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/character-entities-html4": {
@@ -3905,8 +3918,9 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7694,14 +7708,15 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "random-access-file": "^4.0.7",
     "random-access-memory": "^6.2.1",
     "rimraf": "^5.0.5",
+    "supports-color": "^9.4.0",
     "tempy": "^3.1.0",
     "ts-proto": "^1.156.7",
     "typedoc": "^0.26.7",

--- a/src/index-writer/index.js
+++ b/src/index-writer/index.js
@@ -97,7 +97,7 @@ export class IndexWriter {
       const indexer = this.#indexers.get(schemaName)
       if (!indexer) continue // Won't happen, but TS doesn't know that
       indexer.batch(docs)
-      if (this.#l.enabled) {
+      if (this.#l.log.enabled) {
         for (const doc of docs) {
           this.#l.log(
             'Indexed %s %S @ %S',

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -674,6 +674,14 @@ export class MapeoManager extends TypedEmitter {
       isConfigSynced
     ) {
       return true
+    } else {
+      this.#l.log(
+        'Pending initial sync: role %s, projectSettings %o, auth %o, config %o',
+        isRoleSynced,
+        isProjectSettingsSynced,
+        isAuthSynced,
+        isConfigSynced
+      )
     }
     return new Promise((resolve, reject) => {
       /** @param {import('./sync/sync-state.js').State} syncState */

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -552,7 +552,6 @@ export class MapeoProject extends TypedEmitter {
         await this.#dataTypes.projectSettings.getByDocId(this.#projectId)
       )
     } catch (e) {
-      this.#l.log('No project settings')
       return /** @type {EditableProjectSettings} */ (EMPTY_PROJECT_SETTINGS)
     }
   }

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -261,7 +261,9 @@ export class SyncApi extends TypedEmitter {
       syncEnabledState = 'presync'
     }
 
-    this.#l.log(`Setting sync enabled state to "${syncEnabledState}"`)
+    if (syncEnabledState !== this.#previousSyncEnabledState) {
+      this.#l.log(`Setting sync enabled state to "${syncEnabledState}"`)
+    }
     for (const peerSyncController of this.#peerSyncControllers.values()) {
       peerSyncController.setSyncEnabledState(syncEnabledState)
     }
@@ -435,7 +437,6 @@ export class SyncApi extends TypedEmitter {
     for (const result of ownershipResults) {
       if (result.status === 'rejected') continue
       await this.#validateRoleAndAddCoresForPeer(result.value)
-      this.#l.log('Added cores for device %S', result.value.docId)
     }
   }
 
@@ -457,10 +458,8 @@ export class SyncApi extends TypedEmitter {
               coreOwnershipDocId
             )
             await this.#validateRoleAndAddCoresForPeer(coreOwnershipDoc)
-            this.#l.log('Added cores for device %S', coreOwnershipDocId)
           } catch (_) {
             // Ignore, we'll add these when the role is added
-            this.#l.log('No role for device %S', coreOwnershipDocId)
           }
         })()
       )
@@ -485,6 +484,7 @@ export class SyncApi extends TypedEmitter {
       const coreKey = Buffer.from(coreOwnership[`${ns}CoreId`], 'hex')
       this.#coreManager.addCore(coreKey, ns)
     }
+    this.#l.log('Added non-auth cores for peer %S', peerDeviceId)
   }
 }
 


### PR DESCRIPTION
Several improvements to debug logging, to improve our ability to parse the logs and gather useful information:

- Fix a memory issue in the `PeerSyncController` logger, that was creating a new `Debugger` instance (by calling `Logger.create()`) each time anything was logged.
- Fixed a memory issue in `PeerSyncController` which was adding a `peer-remove` event listener every time a core is replicated, and never removing the listener. This was solely for debugging. Now only adds the listener if debugging is enabled.
- Log the namespace of cores that are replicated or unreplicated.
- Change the function signatures in `PeerSyncController` and expose the `CoreRecord` of the creator core, to enable this namespace logging.
- Removed unnecesary logging when handling discovery keys in `PeerSyncController`.
- `SyncApi`: only log change of sync enabled state, rather than logging it on every state update.
- `SyncApi`: Remove superflous logging for when cores are added (adding cores is logged by core manager).
- Explicitly include the `supports-color` dev dependency, which `debug` uses if available to support more colors (it was using this anyway, as a transitive dependency included by an unrelated module, but this makes the dependency more explicit).
- Remove unhelpful "No project settings" log in `MapeoProject`
- Add logging to `MapeoManager.#waitForInitialSync` to show why sync is pending.
- Configure the `debug` module to color debug lines according to the deviceId, rather than a different color for each namespace. Simplifies identifying which debug lines come from each peer in tests.
- `Logger.log` is now an instance of `debug.Debugger`, with its properties such as `Debugger.enabled`. Before it was just a function that wrapped `debug.Debugger`.