### PR TITLE
chore: add pre-have logging to CoreSyncState

### DIFF
--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -44,21 +44,10 @@ export class PeerSyncController {
    * @param {Logger} [opts.logger]
    */
   constructor({ protomux, coreManager, syncState, roles, logger }) {
-    const log = Logger.create('peer', logger).log
-    this.#log = Object.assign(
-      /**
-       * @param {any} formatter
-       * @param  {...any} args
-       */
-      (formatter, ...args) => {
-        return log.apply(null, [
-          `[%h] ${formatter}`,
-          protomux.stream.remotePublicKey,
-          ...args,
-        ])
-      },
-      log
-    )
+    const logPrefix = `[${protomux.stream.remotePublicKey
+      ?.toString('hex')
+      .slice(0, 7)}] `
+    this.#log = Logger.create('peer', logger, { prefix: logPrefix }).log
     this.#coreManager = coreManager
     this.#protomux = protomux
     this.#roles = roles

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -97,6 +97,7 @@ export class SyncApi extends TypedEmitter {
       coreManager,
       throttleMs,
       peerSyncControllers: this.#pscByPeerId,
+      logger,
     })
     this[kSyncState].setMaxListeners(0)
     this[kSyncState].on('state', (namespaceSyncState) => {

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -24,8 +24,9 @@ export class SyncState extends TypedEmitter {
    * @param {import('../core-manager/index.js').CoreManager} opts.coreManager
    * @param {Map<string, import('./peer-sync-controller.js').PeerSyncController>} opts.peerSyncControllers
    * @param {number} [opts.throttleMs]
+   * @param {import('../logger.js').Logger} [opts.logger]
    */
-  constructor({ coreManager, peerSyncControllers, throttleMs = 200 }) {
+  constructor({ coreManager, peerSyncControllers, throttleMs = 200, logger }) {
     super()
     const throttledHandleUpdate = throttle(throttleMs, this.#handleUpdate)
     for (const namespace of NAMESPACES) {
@@ -34,6 +35,7 @@ export class SyncState extends TypedEmitter {
         coreManager,
         onUpdate: throttledHandleUpdate,
         peerSyncControllers,
+        logger,
       })
     }
   }


### PR DESCRIPTION
It's useful to know when pre-have messages are being received. This requires logging on `CoreSyncState`, which unfortunately involves passing the Logger instance down through various parent classes.

This PR also moves the code that was in `PeerSyncController` to add a prefix to each log message in to the `Logger` class, and re-uses this code in `CoreSyncState`.

It's useful to have a prefix for each log message, rather than use a different debug namespace, to keep logs more readable. The prefix is used to reference the peerId being synced with, or the core discovery key being handled. The debug namespace contains the deviceId as the postfix, so adding additional ids to the namespace would be confusing.
