### PR TITLE
fix: sync state with disconnected peers (take 2)

### DIFF
--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -106,6 +106,15 @@ export class NamespaceSyncState {
   }
 
   /**
+   * @param {string} peerId
+   */
+  disconnectPeer(peerId) {
+    for (const css of this.#coreStates.values()) {
+      css.disconnectPeer(peerId)
+    }
+  }
+
+  /**
    * @param {import('hypercore')<"binary", Buffer>} core
    * @param {Buffer} coreKey
    */

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -407,10 +407,6 @@ export class SyncApi extends TypedEmitter {
    * @param {{ protomux: import('protomux')<import('@hyperswarm/secret-stream')>, remotePublicKey: Buffer }} peer
    */
   #handlePeerDisconnect = (peer) => {
-    this.#l.log(
-      '@@@@ handlePeerRemove %h',
-      peer.protomux.stream.remotePublicKey
-    )
     const { protomux } = peer
     if (!this.#peerSyncControllers.has(protomux)) {
       this.#l.log(

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -50,6 +50,15 @@ export class SyncState extends TypedEmitter {
   }
 
   /**
+   * @param {string} peerId
+   */
+  disconnectPeer(peerId) {
+    for (const nss of Object.values(this.#syncStates)) {
+      nss.disconnectPeer(peerId)
+    }
+  }
+
+  /**
    * @returns {State}
    */
   getState() {


### PR DESCRIPTION
There are two scenarios where a disconnected peer results in sync never showing as complete.

**Scenario A**:
1. 3 or more peers are connected.
2. A peer disconnects (e.g. wifi off)
3. Remaining peers add data (including inviting another device)
4. Any peer that was previously connected to the peer that disconnected thinks that the disconnected peer still "wants" data, so sync never completes.

**Scenario B**:
1. 3 or more peers are connected
2. A peer adds some data that is not synced (e.g. adds an observation while sync is not enabled)
3. That peer disconnects
4. Remaining peers attempt to sync.
5. Sync never completes because peers are waiting for data from disconnected peer.

Note that these bugs affect `project.$sync.waitForSync()`, which I don't think the front-end is not currently using. The mechanism used for determining if sync is completed in the front-end _may_ still work.

### Fix

This PR fixes what appears to be an oversight for what happens when a peer disconnects (e.g. turns wifi off or force-closes app). We were removing the `PeerSyncController`, but we were not removing the remote state from `CoreSyncState`. I think I had some confusion about whether we should keep remote states for disconnected peers. For now, this PR "fixes" this to just completely remove remote states for disconnected peers. If we think keeping the remote state for disconnected peers in the future is useful, we can add it at a later stage. Right now, the remote state for a disconnected peer is just a cause of bugs, so not useful.
