### PR TITLE
feat: use req.hostname instead of manually configured server host.

### DIFF
--- a/src/server/allowed-hosts-plugin.js
+++ b/src/server/allowed-hosts-plugin.js
@@ -1,0 +1,19 @@
+import createFastifyPlugin from 'fastify-plugin'
+
+/**
+ * @typedef {object} AllowedHostsPluginOptions
+ * @property {string[]} [allowedHosts]
+ */
+
+/** @type {import('fastify').FastifyPluginAsync<AllowedHostsPluginOptions>} */
+const comapeoPlugin = async function (fastify, { allowedHosts }) {
+  if (!allowedHosts) {
+    return
+  }
+  const allowedHostsSet = new Set(allowedHosts)
+  fastify.addHook('onRequest', async function (req) {
+    this.assert(allowedHostsSet.has(req.hostname), 403, 'Forbidden')
+  })
+}
+
+export default createFastifyPlugin(comapeoPlugin, { name: 'allowedHosts' })

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -11,6 +11,7 @@ import comapeoPlugin from './comapeo-plugin.js'
  * @typedef {object} OtherServerOptions
  * @prop {FastifyServerOptions['logger']} [logger]
  * @prop {string} serverBearerToken
+ * @prop {string} serverName
  */
 
 /** @typedef {ComapeoPluginOptions & OtherServerOptions} ServerOptions */
@@ -22,6 +23,7 @@ import comapeoPlugin from './comapeo-plugin.js'
 export default function createServer({
   logger,
   serverBearerToken,
+  serverName,
   ...comapeoPluginOpts
 }) {
   const fastify = createFastify({ logger })
@@ -30,7 +32,7 @@ export default function createServer({
   fastify.register(comapeoPlugin, comapeoPluginOpts)
   fastify.register(routes, {
     serverBearerToken,
-    serverPublicBaseUrl: comapeoPluginOpts.serverPublicBaseUrl,
+    serverName,
   })
   return fastify
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,6 +3,7 @@ import createFastify from 'fastify'
 import fastifySensible from '@fastify/sensible'
 import routes from './routes.js'
 import comapeoPlugin from './comapeo-plugin.js'
+import baseUrlPlugin from './base-url-plugin.js'
 /** @import { FastifyServerOptions } from 'fastify' */
 /** @import { ComapeoPluginOptions } from './comapeo-plugin.js' */
 
@@ -29,6 +30,7 @@ export default function createServer({
   const fastify = createFastify({ logger })
   fastify.register(fastifyWebsocket)
   fastify.register(fastifySensible, { sharedSchemaId: 'HttpError' })
+  fastify.register(baseUrlPlugin)
   fastify.register(comapeoPlugin, comapeoPluginOpts)
   fastify.register(routes, {
     serverBearerToken,

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,6 +4,7 @@ import fastifySensible from '@fastify/sensible'
 import routes from './routes.js'
 import comapeoPlugin from './comapeo-plugin.js'
 import baseUrlPlugin from './base-url-plugin.js'
+import allowedHostsPlugin from './allowed-hosts-plugin.js'
 /** @import { FastifyServerOptions } from 'fastify' */
 /** @import { ComapeoPluginOptions } from './comapeo-plugin.js' */
 
@@ -13,6 +14,7 @@ import baseUrlPlugin from './base-url-plugin.js'
  * @prop {FastifyServerOptions['logger']} [logger]
  * @prop {string} serverBearerToken
  * @prop {string} serverName
+ * @prop {string[]} [allowedHosts]
  */
 
 /** @typedef {ComapeoPluginOptions & OtherServerOptions} ServerOptions */
@@ -25,11 +27,13 @@ export default function createServer({
   logger,
   serverBearerToken,
   serverName,
+  allowedHosts,
   ...comapeoPluginOpts
 }) {
   const fastify = createFastify({ logger })
   fastify.register(fastifyWebsocket)
   fastify.register(fastifySensible, { sharedSchemaId: 'HttpError' })
+  fastify.register(allowedHostsPlugin, { allowedHosts })
   fastify.register(baseUrlPlugin)
   fastify.register(comapeoPlugin, comapeoPluginOpts)
   fastify.register(routes, {

--- a/src/server/base-url-plugin.js
+++ b/src/server/base-url-plugin.js
@@ -1,0 +1,11 @@
+import createFastifyPlugin from 'fastify-plugin'
+
+/** @type {import('fastify').FastifyPluginAsync<never>} */
+const baseUrlPlugin = async function (fastify) {
+  fastify.decorateRequest('baseUrl', null)
+  fastify.addHook('onRequest', async function (req) {
+    req.baseUrl = new URL(this.prefix, `${req.protocol}://${req.hostname}`)
+  })
+}
+
+export default createFastifyPlugin(baseUrlPlugin, { name: 'baseUrl' })

--- a/src/server/comapeo-plugin.js
+++ b/src/server/comapeo-plugin.js
@@ -2,10 +2,7 @@ import { MapeoManager } from '../mapeo-manager.js'
 import createFastifyPlugin from 'fastify-plugin'
 
 /**
- * @typedef {Omit<ConstructorParameters<typeof MapeoManager>[0], 'fastify'> & {
- *   serverName: string;
- *   serverPublicBaseUrl: string;
- * }} ComapeoPluginOptions
+ * @typedef {Omit<ConstructorParameters<typeof MapeoManager>[0], 'fastify'>} ComapeoPluginOptions
  */
 
 /** @type {import('fastify').FastifyPluginAsync<ComapeoPluginOptions>} */
@@ -17,16 +14,6 @@ const comapeoPlugin = async function (fastify, opts) {
     // deviceType: 'selfHostedServer',
   })
   fastify.decorate('comapeo', comapeo)
-  const existingDeviceInfo = comapeo.getDeviceInfo()
-  if (existingDeviceInfo.deviceType === 'device_type_unspecified') {
-    await comapeo.setDeviceInfo({
-      deviceType: 'selfHostedServer',
-      name: opts.serverName,
-      selfHostedServerDetails: {
-        baseUrl: opts.serverPublicBaseUrl,
-      },
-    })
-  }
 }
 
 export default createFastifyPlugin(comapeoPlugin, { name: 'comapeo' })

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -114,11 +114,7 @@ export default async function routes(
         403,
         'Server is already linked to a project'
       )
-
-      const baseUrl = new URL(
-        fastify.prefix,
-        `${req.protocol}://${req.hostname}`
-      ).toString()
+      const baseUrl = req.baseUrl.toString()
 
       const existingDeviceInfo = this.comapeo.getDeviceInfo()
       // We don't set device info until this point. We trust that `req.hostname`
@@ -182,10 +178,6 @@ export default async function routes(
     async function (req, reply) {
       const { projectPublicId } = req.params
       const project = await this.comapeo.getProject(projectPublicId)
-      const baseUrl = new URL(
-        fastify.prefix,
-        `${req.protocol}://${req.hostname}`
-      )
 
       reply.send({
         data: (await project.observation.getMany()).map((obs) => ({
@@ -198,7 +190,7 @@ export default async function routes(
             url: new URL(
               // TODO: Support other variants
               `projects/${projectPublicId}/attachments/${attachment.driveDiscoveryId}/${attachment.type}/${attachment.name}`,
-              baseUrl
+              req.baseUrl
             ),
           })),
         })),

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -82,7 +82,6 @@ if (!rootKey || rootKey.length !== 16) {
 const fastify = createServer({
   serverName: config.SERVER_NAME,
   serverBearerToken: config.SERVER_BEARER_TOKEN,
-  serverPublicBaseUrl: config.SERVER_PUBLIC_BASE_URL,
   rootKey,
   coreStorage,
   dbFolder,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -9,4 +9,7 @@ declare module 'fastify' {
   interface FastifyInstance {
     comapeo: MapeoManager
   }
+  interface FastifyRequest {
+    baseUrl: URL
+  }
 }

--- a/test-e2e/server-integration.js
+++ b/test-e2e/server-integration.js
@@ -201,16 +201,15 @@ test('observations endpoint', async (t) => {
 
       await project.$sync.waitForSync('full')
 
-      const response = await fetch(
-        `${BASE_URL}projects/${projectId}/observations`,
-        {
-          headers: { Authorization: 'Bearer ' + BEARER_TOKEN },
-        }
-      )
+      const response = await server.inject({
+        authority: `localhost:${PORT}`,
+        method: 'GET',
+        url: `/projects/${projectId}/observations`,
+        headers: { Authorization: 'Bearer ' + BEARER_TOKEN },
+      })
 
-      assert.equal(response.status, 200)
+      assert.equal(response.statusCode, 200)
 
-      // @ts-expect-error
       const { data } = await response.json()
 
       assert.equal(data.length, 2)

--- a/test-e2e/server-integration.js
+++ b/test-e2e/server-integration.js
@@ -24,7 +24,7 @@ const FIXTURE_THUMBNAIL_PATH = new URL('thumbnail.jpg', FIXTURES_ROOT).pathname
 
 test('server info endpoint', async (t) => {
   const serverName = 'test server'
-  const server = createTestServer(t, serverName)
+  const server = createTestServer(t, { serverName })
   const expectedResponseBody = {
     data: {
       deviceId: server.deviceId,
@@ -36,6 +36,31 @@ test('server info endpoint', async (t) => {
     url: '/info',
   })
   assert.deepEqual(response.json(), expectedResponseBody)
+})
+
+test('allowedHosts valid', async (t) => {
+  const allowedHost = 'www.example.com'
+  const server = createTestServer(t, {
+    allowedHosts: [allowedHost],
+  })
+  const response = await server.inject({
+    authority: allowedHost,
+    method: 'GET',
+    url: '/info',
+  })
+  assert.equal(response.statusCode, 200)
+})
+
+test('allowedHosts invalid', async (t) => {
+  const server = createTestServer(t, {
+    allowedHosts: ['www.example.com'],
+  })
+  const response = await server.inject({
+    authority: 'www.invalid-host.com',
+    method: 'GET',
+    url: '/info',
+  })
+  assert.equal(response.statusCode, 403)
 })
 
 test('add project, sync endpoint available', async (t) => {
@@ -249,18 +274,25 @@ function randomProjectKeys() {
   }
 }
 
+const TEST_SERVER_DEFAULTS = {
+  serverName: 'test server',
+  serverBearerToken: BEARER_TOKEN,
+}
+
 /**
- *
  * @param {import('node:test').TestContext} t
+ * @param {Partial<import('../src/server/app.js').ServerOptions>} [serverOptions]
  * @returns {ReturnType<typeof createServer> & { deviceId: string }}
  */
-function createTestServer(t, serverName = 'test server') {
+function createTestServer(t, serverOptions) {
+  const serverName =
+    serverOptions?.serverName || TEST_SERVER_DEFAULTS.serverName
   const managerOptions = getManagerOptions(serverName)
   const km = new KeyManager(managerOptions.rootKey)
   const server = createServer({
     ...managerOptions,
-    serverName,
-    serverBearerToken: BEARER_TOKEN,
+    ...TEST_SERVER_DEFAULTS,
+    ...serverOptions,
   })
   t.after(() => server.close())
   Object.defineProperty(server, 'deviceId', {

--- a/test-e2e/server.js
+++ b/test-e2e/server.js
@@ -47,7 +47,7 @@ test('adding a server peer', async (t) => {
   )
   assert.equal(
     serverPeer.selfHostedServerDetails?.baseUrl,
-    'http://localhost:9876',
+    'http://localhost:9876/',
     'server peer stores base URL'
   )
 })
@@ -142,12 +142,11 @@ async function createTestServer(t) {
   const server = createServer({
     ...getManagerOptions('test server'),
     serverName: 'test server',
-    serverPublicBaseUrl: 'http://localhost:' + port,
     serverBearerToken: 'ignored',
   })
-  const serverAddress = await server.listen({ port })
+  await server.listen({ port })
   t.after(() => server.close())
-  return serverAddress
+  return `http://localhost:${port}`
 }
 
 /**


### PR DESCRIPTION
This removes the server option `serverPublicBaseUrl` and instead uses the hostname from the `Host` header (or `X-Forwarded-Host` if [`trustProxy`](https://fastify.dev/docs/v4.28.x/Reference/Server/#factory-trust-proxy) is enabled).

The reason for this change is to simplify server configuration and avoiding errors stemming from the server value not matching the URL the server is accessible on.

The `Host` header is required by the HTTP 1.1 spec, so will always be present and can be trusted. We use the value that the client sends when creating a project, so the value used will be the value the client enters when they add the server.