### PR TITLE
fix: avoid uncaught websocket errors

### DIFF
--- a/src/member-api.js
+++ b/src/member-api.js
@@ -344,6 +344,7 @@ export class MemberApi extends TypedEmitter {
         ? 'ws:'
         : 'wss:'
     const websocket = new WebSocket(websocketUrl)
+    websocket.on('error', noop)
     const replicationStream = this.#getReplicationStream()
     wsCoreReplicator(websocket, replicationStream)
 
@@ -357,6 +358,7 @@ export class MemberApi extends TypedEmitter {
 
     websocket.close()
     await once(websocket, 'close')
+    websocket.off('error', noop)
   }
 
   /**

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -312,6 +312,8 @@ export class SyncApi extends TypedEmitter {
           }
 
           const websocket = new WebSocket(url)
+          // TODO: Handle websocket errors
+          websocket.on('error', noop)
 
           // TODO: Handle errors (maybe with the `unexpected-response` event?)
 
@@ -320,6 +322,7 @@ export class SyncApi extends TypedEmitter {
 
           this.#serverWebsockets.set(url, websocket)
           websocket.once('close', () => {
+            websocket.off('error', noop)
             this.#serverWebsockets.delete(url)
           })
         }


### PR DESCRIPTION
Not sure the best way to address this, but currently we aren't listening to the `error` event on websocket instances, which means that any errors raise an uncaught exception and crash the app. This should fix that for now.