### PR TITLE
feat: add endpoint for maps plugin to get info about custom map

### DIFF
--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -4,7 +4,7 @@ import { fetch } from 'undici'
 import { Server as SMPServerPlugin } from 'styled-map-package'
 
 import { noop } from '../utils.js'
-import { NotFoundError } from './utils.js'
+import { NotFoundError, ENOENTError } from './utils.js'
 
 /** @import { FastifyPluginAsync } from 'fastify' */
 /** @import { Stats } from 'node:fs' */
@@ -53,7 +53,7 @@ export async function plugin(fastify, opts) {
         stats = await fs.stat(customMapPath)
       } catch (err) {
         if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-          throw new NotFoundError(customMapPath)
+          throw new ENOENTError(customMapPath)
         }
 
         throw err

--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -45,7 +45,7 @@ export async function plugin(fastify, opts) {
           : undefined
 
       return {
-        created: stats.birthtime,
+        created: stats.ctime,
         size: stats.size,
         name: styleJsonName || path.parse(customMapPath).name,
       }

--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -45,7 +45,7 @@ export async function plugin(fastify, opts) {
           : undefined
 
       return {
-        created: stats.ctime,
+        created: stats.birthtime,
         size: stats.size,
         name: styleJsonName || path.parse(customMapPath).name,
       }

--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -4,8 +4,10 @@ import { fetch } from 'undici'
 import { Server as SMPServerPlugin } from 'styled-map-package'
 
 import { noop } from '../utils.js'
+import { NotFoundError } from './utils.js'
 
 /** @import { FastifyPluginAsync } from 'fastify' */
+/** @import { Stats } from 'node:fs' */
 
 export const CUSTOM_MAP_PREFIX = 'custom'
 export const FALLBACK_MAP_PREFIX = 'fallback'
@@ -30,11 +32,34 @@ export async function plugin(fastify, opts) {
         baseUrl.href += '/'
       }
 
-      const style = await (
-        await fetch(new URL(`${CUSTOM_MAP_PREFIX}/style.json`, baseUrl))
-      ).json()
+      const customStyleJsonUrl = new URL(
+        `${CUSTOM_MAP_PREFIX}/style.json`,
+        baseUrl
+      )
+      const response = await fetch(customStyleJsonUrl)
 
-      const stats = await fs.stat(customMapPath)
+      if (response.status === 404) {
+        throw new NotFoundError(customStyleJsonUrl.href)
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to get style from ${customStyleJsonUrl.href}`)
+      }
+
+      /** @type {Stats | undefined} */
+      let stats
+
+      try {
+        stats = await fs.stat(customMapPath)
+      } catch (err) {
+        if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+          throw new NotFoundError(customMapPath)
+        }
+
+        throw err
+      }
+
+      const style = await response.json()
 
       const styleJsonName =
         typeof style === 'object' &&

--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import { fetch } from 'undici'
 import { Server as SMPServerPlugin } from 'styled-map-package'
 
@@ -19,9 +21,39 @@ export const FALLBACK_MAP_PREFIX = 'fallback'
 /** @type {FastifyPluginAsync<MapsPluginOpts>} */
 export async function plugin(fastify, opts) {
   if (opts.customMapPath) {
+    const { customMapPath } = opts
+
+    fastify.get(`/${CUSTOM_MAP_PREFIX}/info`, async () => {
+      const baseUrl = new URL(fastify.prefix, fastify.listeningOrigin)
+
+      if (!baseUrl.href.endsWith('/')) {
+        baseUrl.href += '/'
+      }
+
+      const style = await (
+        await fetch(new URL(`${CUSTOM_MAP_PREFIX}/style.json`, baseUrl))
+      ).json()
+
+      const stats = await fs.stat(customMapPath)
+
+      const styleJsonName =
+        typeof style === 'object' &&
+        style &&
+        'name' in style &&
+        typeof style.name === 'string'
+          ? style.name
+          : undefined
+
+      return {
+        created: stats.ctime,
+        size: stats.size,
+        name: styleJsonName || path.parse(customMapPath).name,
+      }
+    })
+
     fastify.register(SMPServerPlugin, {
       prefix: CUSTOM_MAP_PREFIX,
-      filepath: opts.customMapPath,
+      filepath: customMapPath,
     })
   }
 

--- a/src/fastify-plugins/utils.js
+++ b/src/fastify-plugins/utils.js
@@ -7,6 +7,12 @@ export const NotFoundError = createError(
   404
 )
 
+export const ENOENTError = createError(
+  'FST_ENOENT',
+  "ENOENT: no such file or directory '%s'",
+  404
+)
+
 /**
  * @param {import('node:http').Server} server
  * @param {{ timeout?: number }} [options]

--- a/test/fastify-plugins/maps.js
+++ b/test/fastify-plugins/maps.js
@@ -14,7 +14,6 @@ import {
   DEFAULT_FALLBACK_MAP_FILE_PATH,
   DEFAULT_ONLINE_STYLE_URL,
 } from '../../src/mapeo-manager.js'
-import { hashObject } from '../../src/utils.js'
 
 const SAMPLE_SMP_FIXTURE_PATH = new URL(
   '../fixtures/maps/maplibre-demotiles.smp',
@@ -291,15 +290,11 @@ test('custom map info endpoint returns expected info when available', async (t) 
 
   const info = response.json()
 
-  assert.equal(typeof info.name, 'string')
-  assert.equal(typeof info.created, 'string')
-  assert.equal(typeof info.size, 'number')
-
-  assert.equal(
-    hashObject(info),
-    'c6684f9b8bea0be698631c8d4ba9e6c85e0b312b10fa2e4273f35d1e01ee9118',
-    'custom map info matches snapshot'
-  )
+  assert.deepEqual(info, {
+    created: '2024-10-09T17:41:16.103Z',
+    size: 2815018,
+    name: 'MapLibre',
+  })
 })
 
 /**

--- a/test/fastify-plugins/maps.js
+++ b/test/fastify-plugins/maps.js
@@ -291,7 +291,7 @@ test('custom map info endpoint returns expected info when available', async (t) 
 
   assert.equal(
     hashObject(response.json()),
-    'ef2ae6b5a1298e608c743a91bb7fba7c55ea63427e34cfb52b808eaaa6625b61',
+    '5bc7093106b4e586df4cea74154f02e35e12f0e13ee6d08178b741e0530712e3',
     'custom map info matches snapshot'
   )
 })

--- a/test/fastify-plugins/maps.js
+++ b/test/fastify-plugins/maps.js
@@ -297,7 +297,7 @@ test('custom map info endpoint returns expected info when available', async (t) 
 
   assert.equal(
     hashObject(info),
-    '5bc7093106b4e586df4cea74154f02e35e12f0e13ee6d08178b741e0530712e3',
+    'c6684f9b8bea0be698631c8d4ba9e6c85e0b312b10fa2e4273f35d1e01ee9118',
     'custom map info matches snapshot'
   )
 })

--- a/test/fastify-plugins/maps.js
+++ b/test/fastify-plugins/maps.js
@@ -289,8 +289,14 @@ test('custom map info endpoint returns expected info when available', async (t) 
 
   assert.equal(response.statusCode, 200)
 
+  const info = response.json()
+
+  assert.equal(typeof info.name, 'string')
+  assert.equal(typeof info.created, 'string')
+  assert.equal(typeof info.size, 'number')
+
   assert.equal(
-    hashObject(response.json()),
+    hashObject(info),
     '5bc7093106b4e586df4cea74154f02e35e12f0e13ee6d08178b741e0530712e3',
     'custom map info matches snapshot'
   )


### PR DESCRIPTION
Closes #827 

Stacked on #896 

- adds a GET endpoint for the maps plugin located at `<prefix>/custom/info` to provide the name, size, and creation time of the custom map file if it exists
