### PR TITLE
fix: support maps that may be removed or replaced in map server plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "sodium-universal": "^4.0.0",
         "start-stop-state-machine": "^1.2.0",
         "streamx": "^2.19.0",
-        "styled-map-package": "^1.1.0",
+        "styled-map-package": "^2.0.0",
         "sub-encoder": "^2.1.1",
         "throttle-debounce": "^5.0.0",
         "tiny-typed-emitter": "^2.1.0",
@@ -8824,9 +8824,9 @@
       }
     },
     "node_modules/styled-map-package": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/styled-map-package/-/styled-map-package-1.1.0.tgz",
-      "integrity": "sha512-QzaB5nvbuZKteIlGAFVEsxyuXWJQ5bObFntgrk9CZdsEl19ErTexr3vThpvl/ABCWhWYUe8N8kpR6XevxmHlDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/styled-map-package/-/styled-map-package-2.0.0.tgz",
+      "integrity": "sha512-CGjyypTc+SQ97Y2XopJ9yOuB8aQMqAMWSLyUBStnntuomXNzgMUhhS9GOafyBhUJqm01UONWi82tJhXhZ05wWw==",
       "dependencies": {
         "@fastify/static": "^7.0.4",
         "@mapbox/sphericalmercator": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "sodium-universal": "^4.0.0",
     "start-stop-state-machine": "^1.2.0",
     "streamx": "^2.19.0",
-    "styled-map-package": "^1.1.0",
+    "styled-map-package": "^2.0.0",
     "sub-encoder": "^2.1.1",
     "throttle-debounce": "^5.0.0",
     "tiny-typed-emitter": "^2.1.0",


### PR DESCRIPTION
Updates `styled-map-package` to v2.0.0, which adds support for custom maps that may be removed or replaced during the lifetime of the server instance. This addresses a need for the consuming apps, as we have the ability to delete the custom map file at any point.