### PR TITLE
fix: prevent fastify v5 from being installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "drizzle-orm": "^0.30.8",
-        "fastify": ">= 4",
+        "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",
         "hyperblobs": "2.3.0",
         "hypercore": "10.17.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "debug": "^4.3.4",
     "dot-prop": "^9.0.0",
     "drizzle-orm": "^0.30.8",
-    "fastify": ">= 4",
+    "fastify": "^4.0.0",
     "fastify-plugin": "^4.5.1",
     "hyperblobs": "2.3.0",
     "hypercore": "10.17.0",


### PR DESCRIPTION
Our range for `fastify` caused fresh installations of this package to install fastify v5, which is not supported by the relevant plugins we use. This PR updates the range such that it only allows v4.X.X of fastify to be installed