### PR TITLE
test: use correct MIME type for MP3

### DIFF
--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -304,7 +304,7 @@ test('retrieving audio file', async (t) => {
   await t.test('creating audio', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'audio.mp3') },
-      blobMetadata({ mimeType: 'audio/mp3' })
+      blobMetadata({ mimeType: 'audio/mpeg' })
     )
     const blobUrl = await project.$blobs.getUrl({
       ...blobId,
@@ -320,7 +320,7 @@ test('retrieving audio file', async (t) => {
     assert.equal(response.status, 200, 'response status ok')
     assert.equal(
       response.headers.get('content-type'),
-      'audio/mp3',
+      'audio/mpeg',
       'matching content type header'
     )
     const expected = await fs.readFile(join(BLOB_FIXTURES_DIR, 'audio.mp3'))


### PR DESCRIPTION
This is a test-only change.

According to [Apache's list][0], the correct MIME type for `.mp3` files is `audio/mpeg`, not `audio/mp3`.

[0]: https://github.com/apache/httpd/blob/f5c4355420d4463c860aa0d85757bfb7a2dd0a40/docs/conf/mime.types#L1441
