### PR TITLE
fix: fix updating comments in lockfile-changes workflow

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -29,7 +29,8 @@ jobs:
           private-key: ${{ secrets.LOCKFILE_BOT_PRIVATE_KEY }}
       - name: NPM Lockfile Changes
         # The original doesn't support v3 lockfiles so we use a fork that adds support for them
-        uses: rvanvelzen/npm-lockfile-changes@6fded38b5a054f5ab49efd6850668e796f780604
+        # The fork doesn't update comments by an app token, so we use our own fork
+        uses: digidem/npm-lockfile-changes@fix/update-comments
         with:
           token: ${{ steps.app-token.outputs.token }}
           updateComment: true

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -30,7 +30,7 @@ jobs:
       - name: NPM Lockfile Changes
         # The original doesn't support v3 lockfiles so we use a fork that adds support for them
         # The fork doesn't update comments by an app token, so we use our own fork
-        uses: digidem/npm-lockfile-changes@fix/update-comments
+        uses: digidem/npm-lockfile-changes@614dfc33742374cb40bec2878e5b690580d11ede
         with:
           token: ${{ steps.app-token.outputs.token }}
           updateComment: true


### PR DESCRIPTION
This fixes the updating of comments by the lockfile-changes workflow. It requires a patch to the action, so we are now using our fork: https://github.com/digidem/npm-lockfile-changes/pull/1

A small thing, but it's been frustrating me getting all comments on the PR from this bot. The issue was happening because we are using a custom github app token to run the action.