### PR TITLE
chore: use more restrictive types for `timingSafeEqual`

### DIFF
--- a/src/lib/timing-safe-equal.js
+++ b/src/lib/timing-safe-equal.js
@@ -1,8 +1,8 @@
 import * as crypto from 'node:crypto'
 
 /**
- * @param {string | NodeJS.ArrayBufferView} value
- * @returns {NodeJS.ArrayBufferView}
+ * @param {Readonly<string | Uint8Array>} value
+ * @returns {Uint8Array}
  */
 const bufferify = (value) =>
   // We use UTF-16 because it's the only supported encoding that doesn't
@@ -19,7 +19,7 @@ const bufferify = (value) =>
  * Like `crypto.timingSafeEqual`, but works with strings and doesn't throw if
  * lengths differ.
  *
- * @template {string | NodeJS.ArrayBufferView} T
+ * @template {string | Uint8Array} T
  * @param {T} a
  * @param {T} b
  * @returns {boolean}


### PR DESCRIPTION
This is a types-only change.

[`crypto.timingSafeEqual`][0] has some subtle behavior (highlighted in bold red in the docs!) when passing a `Float32Array` or `Float64Array`.  Rather than adapt our wrapper to support this unusual situation, this updates the types to avoid it.

We never took advantage of this unusual case, and now we are even less likely to.

I plan to yolo-merge this if CI passes.

[0]: https://nodejs.org/api/crypto.html#cryptotimingsafeequala-b
