### PR TITLE
chore: remove paths filter for lockfile workflow

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,8 +1,6 @@
 name: Check Lockfile
 on:
   pull_request:
-    paths:
-      - 'package-lock.json'
 
 jobs:
   lockfile_version:


### PR DESCRIPTION
The "Check Lockfile" workflow had a paths filter
in the trigger, to only run when package-lock.json
is modified. Unfortunately there is an edge-case,
where package-lock.json is modified, and the
lockfile changes check posts a comment, and then
the package-lock.json changes are reverted, but
the lockfile changes check does not run again,
because now the PR has not updates to
`package-lock.json`.

This workflow is very fast compared with the other
checks in the repo, so I think it's ok to run for
every PR sync event.