### PR TITLE
feat: set own device info to "self-hosted server"

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -736,9 +736,7 @@ export class MapeoManager extends TypedEmitter {
   }
 
   /**
-   * @typedef {Exclude<
-   * import('./schema/client.js').DeviceInfoParam['deviceType'],
-   * 'selfHostedServer'>} RPCDeviceType
+   * @typedef {import('./schema/client.js').DeviceInfoParam['deviceType']} RPCDeviceType
    */
 
   /**
@@ -765,13 +763,22 @@ export class MapeoManager extends TypedEmitter {
       })
     )
 
-    await Promise.all(
-      this.#localPeers.peers
-        .filter(({ status }) => status === 'connected')
-        .map((peer) =>
-          this.#localPeers.sendDeviceInfo(peer.deviceId, deviceInfo)
-        )
-    )
+    if (deviceInfo.deviceType !== 'selfHostedServer') {
+      // We have to make a copy of this because TypeScript can't guarantee that
+      // `deviceInfo` won't be mutated by the time it gets to the
+      // `sendDeviceInfo` call below.
+      const deviceInfoToSend = {
+        ...deviceInfo,
+        deviceType: deviceInfo.deviceType,
+      }
+      await Promise.all(
+        this.#localPeers.peers
+          .filter(({ status }) => status === 'connected')
+          .map((peer) =>
+            this.#localPeers.sendDeviceInfo(peer.deviceId, deviceInfoToSend)
+          )
+      )
+    }
 
     this.#l.log('set device info %o', deviceInfo)
   }

--- a/test-e2e/device-info.js
+++ b/test-e2e/device-info.js
@@ -39,6 +39,18 @@ test('write and read deviceInfo', async () => {
     deviceType: 'mobile',
     deviceId: manager.deviceId,
   })
+
+  await manager.setDeviceInfo({
+    name: 'a little server',
+    deviceType: 'selfHostedServer',
+    selfHostedServerDetails: { baseUrl: 'https://comapeo-test.example/' },
+  })
+  assert.deepEqual(manager.getDeviceInfo(), {
+    name: 'a little server',
+    deviceType: 'selfHostedServer',
+    deviceId: manager.deviceId,
+    selfHostedServerDetails: { baseUrl: 'https://comapeo-test.example/' },
+  })
 })
 
 test('device info written to projects', async (t) => {


### PR DESCRIPTION
We added support for this device type in 98d9981dda7aeb1bd724d7b051934db3307565a1. This lets us set it.

I think this is a useful change on its own, but it will make multiple upcoming changes easier.

*I plan to YOLO-merge this* because Gregor and I have already done this work on the `server` branch together, and this just splits it out (and fixes a type error).