### PR TITLE
feat: save self-hosted server details on member info

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -627,7 +627,7 @@ export class MapeoProject extends TypedEmitter {
   }
 
   /**
-   * @param {Pick<import('@comapeo/schema').DeviceInfoValue, 'name' | 'deviceType'>} value
+   * @param {Pick<import('@comapeo/schema').DeviceInfoValue, 'name' | 'deviceType' | 'selfHostedServerDetails'>} value
    * @returns {Promise<import('@comapeo/schema').DeviceInfo>}
    */
   async [kSetOwnDeviceInfo](value) {
@@ -640,6 +640,7 @@ export class MapeoProject extends TypedEmitter {
     const doc = {
       name: value.name,
       deviceType: value.deviceType,
+      selfHostedServerDetails: value.selfHostedServerDetails,
       schemaName: /** @type {const} */ ('deviceInfo'),
     }
 

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -36,6 +36,8 @@ import { ROLES, isRoleIdForNewInvite } from './roles.js'
  * @prop {DeviceInfo['name']} [name]
  * @prop {DeviceInfo['deviceType']} [deviceType]
  * @prop {DeviceInfo['createdAt']} [joinedAt]
+ * @prop {object} [selfHostedServerDetails]
+ * @prop {string} selfHostedServerDetails.baseUrl
  */
 
 export class MemberApi extends TypedEmitter {
@@ -304,6 +306,8 @@ export class MemberApi extends TypedEmitter {
           memberInfo.name = deviceInfo?.name
           memberInfo.deviceType = deviceInfo?.deviceType
           memberInfo.joinedAt = deviceInfo?.createdAt
+          memberInfo.selfHostedServerDetails =
+            deviceInfo?.selfHostedServerDetails
         } catch (err) {
           // Attempting to get someone else may throw because sync hasn't occurred or completed
           // Only throw if attempting to get themself since the relevant information should be available

--- a/test-e2e/members.js
+++ b/test-e2e/members.js
@@ -10,7 +10,13 @@ import {
   MEMBER_ROLE_ID,
   NO_ROLE,
 } from '../src/roles.js'
-import { connectPeers, createManagers, invite, waitForSync } from './utils.js'
+import {
+  connectPeers,
+  createManagers,
+  invite,
+  removeUndefinedFields,
+  waitForSync,
+} from './utils.js'
 import { kDataTypes } from '../src/mapeo-project.js'
 
 test('getting yourself after creating project', async (t) => {
@@ -30,7 +36,7 @@ test('getting yourself after creating project', async (t) => {
     'time of joined project is close to now'
   )
   assert.deepEqual(
-    me,
+    removeUndefinedFields(me),
     {
       deviceId: project.deviceId,
       deviceType: 'tablet',
@@ -45,7 +51,7 @@ test('getting yourself after creating project', async (t) => {
 
   assert.equal(members.length, 1)
   assert.deepEqual(
-    member,
+    removeUndefinedFields(member),
     {
       deviceId: project.deviceId,
       deviceType: 'tablet',
@@ -81,7 +87,7 @@ test('getting yourself after adding project (but not yet synced)', async (t) => 
   )
 
   assert.deepEqual(
-    me,
+    removeUndefinedFields(me),
     {
       deviceId: project.deviceId,
       deviceType: 'tablet',
@@ -96,7 +102,7 @@ test('getting yourself after adding project (but not yet synced)', async (t) => 
 
   assert.equal(members.length, 1)
   assert.deepEqual(
-    member,
+    removeUndefinedFields(member),
     {
       deviceId: project.deviceId,
       deviceType: 'tablet',
@@ -170,7 +176,7 @@ test('getting invited member after invite accepted', async (t) => {
     )
 
     assert.deepEqual(
-      invitedMemberWithoutJoinedAt,
+      removeUndefinedFields(invitedMemberWithoutJoinedAt),
       {
         deviceId: invitee.deviceId,
         deviceType: 'device_type_unspecified',


### PR DESCRIPTION
We added support for self-hosted servers in 98d9981dda7aeb1bd724d7b051934db3307565a1. This saves the details to project-level member info.

This is a follow-up to 191369434887cc5b9908345b2c418e4a1f93325e.

_I plan to YOLO-merge this_ because Gregor and I have already done this work on the `server` branch together, and this just splits it out.