### PR TITLE
Invert "does this entry match the filter" logic

### DIFF
--- a/src/blob-store/downloader.js
+++ b/src/blob-store/downloader.js
@@ -1,8 +1,9 @@
 import { TypedEmitter } from 'tiny-typed-emitter'
 import { createEntriesStream } from './entries-stream.js'
-import { pathPrefixesFromFilter } from './utils.js'
+import { filePathMatchesFilter } from './utils.js'
 
 /** @import Hyperdrive from 'hyperdrive' */
+/** @import { BlobFilter } from '../types.js' */
 
 /**
  * Like hyperdrive.download() but 'live', and for multiple drives.
@@ -32,7 +33,7 @@ export class Downloader extends TypedEmitter {
   #entriesStream
   #processEntriesPromise
   #ac = new AbortController()
-  #pathPrefixes
+  #shouldDownloadFile
 
   /**
    * @param {import('./index.js').THyperdriveIndex} driveIndex
@@ -41,8 +42,11 @@ export class Downloader extends TypedEmitter {
    */
   constructor(driveIndex, { filter } = {}) {
     super()
-    this.#pathPrefixes = filter ? pathPrefixesFromFilter(filter) : []
     this.#driveIndex = driveIndex
+
+    this.#shouldDownloadFile = filter
+      ? filePathMatchesFilter.bind(null, filter)
+      : () => true
 
     this.#entriesStream = createEntriesStream(driveIndex, { live: true })
     this.#entriesStream.once('error', this.#handleError)
@@ -76,12 +80,6 @@ export class Downloader extends TypedEmitter {
       await this.#processEntry(blobs.core, blob)
     }
     throw new Error('Entries stream ended unexpectedly')
-  }
-
-  /** @param {string} filePath */
-  #shouldDownloadFile(filePath) {
-    if (!this.#pathPrefixes.length) return true
-    return this.#pathPrefixes.some((prefix) => filePath.startsWith(prefix))
   }
 
   /**

--- a/test/blob-store/utils.js
+++ b/test/blob-store/utils.js
@@ -1,0 +1,50 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { filePathMatchesFilter } from '../../src/blob-store/utils.js'
+
+test('filePathMatchesFilter', () => {
+  const filter = {
+    photo: ['a', 'b'],
+    video: [],
+  }
+
+  const shouldMatch = [
+    '/photo/a/foo.jpg',
+    '/photo/b/foo.jpg',
+    '/photo/a/',
+    '/video/foo.mp4',
+    '/video/foo/bar.mp4',
+    '/video/',
+    '/video///',
+  ]
+  for (const filePath of shouldMatch) {
+    assert(
+      filePathMatchesFilter(filter, filePath),
+      `${filePath} matches filter`
+    )
+  }
+
+  const shouldntMatch = [
+    '/photo/c/foo.jpg',
+    '/photo/c/',
+    '/photo/a',
+    '/photo/ax/foo.jpg',
+    '/photo/c/../a/foo.jpg',
+    '/photo',
+    '/photo/',
+    '/photo//',
+    '/PHOTO/a/foo.jpg',
+    '/audio/a/foo.mp3',
+    'photo/a/foo.jpg',
+    '//photo/a/foo.jpg',
+    ' /photo/a/foo.jpg',
+    '/hasOwnProperty/',
+    '/hasOwnProperty/a/foo.jpg',
+  ]
+  for (const filePath of shouldntMatch) {
+    assert(
+      !filePathMatchesFilter(filter, filePath),
+      `${filePath} doesn't match filter`
+    )
+  }
+})


### PR DESCRIPTION
To be merged into #940.

Before this change, we turned filters into a list of path prefixes and then checked entry paths against those prefixes. Rough pseudocode:

```javascript
function doesEntryMatchFilter({ path }, filter) {
  const pathPrefixes = pathPrefixesFromFilter(filter)
  return pathPrefixes.some((prefix) => path.startsWith(prefix))
}
```

For performance and simplicity, I think it's cleaner if we "look up" entry paths in the existing filter object. Rough pseudocode:

```javascript
function doesEntryMatchFilter({ path }, filter) {
  const { type, variant } = parsePath(path)
  return filter[type]?.includes(variant)
}
```

I think this has two advantages:

- It's less code. We don't need to worry about de-duping paths (e.g., `/photos/original` versus `/photos/`). We don't need to worry about sketchy paths (e.g., `/photos/garbage/../original`).
- It's faster (at least, in theory). Rather than having to iterate over every path prefix, we only need to iterate over the variants of each path. (This could be further optimized with a `Set`.)
