### PR TITLE
fix: memory leak in `DataStore`

### DIFF
--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -111,7 +111,6 @@ export class DataStore extends TypedEmitter {
       const pending = this.#pendingIndex.get(versionId)
       if (!pending) continue
       pending.resolve()
-      this.#pendingIndex.delete(versionId)
     }
     for (const schemaName of this.schemas) {
       // Unsupported initially
@@ -166,6 +165,7 @@ export class DataStore extends TypedEmitter {
     const deferred = pDefer()
     this.#pendingIndex.set(versionId, deferred)
     await deferred.promise
+    this.#pendingIndex.delete(versionId)
 
     return /** @type {Extract<MapeoDoc, TDoc>} */ (
       decode(block, { coreDiscoveryKey, index })

--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -111,6 +111,7 @@ export class DataStore extends TypedEmitter {
       const pending = this.#pendingIndex.get(versionId)
       if (!pending) continue
       pending.resolve()
+      this.#pendingIndex.delete(versionId)
     }
     for (const schemaName of this.schemas) {
       // Unsupported initially


### PR DESCRIPTION
We have a set of promises waiting to be indexed, and we never removed these promises from the set. This fixes that memory leak.