### PR TITLE
feat: handle incoming blob filters

### DIFF
--- a/src/blob-store/downloader.js
+++ b/src/blob-store/downloader.js
@@ -2,8 +2,8 @@ import { TypedEmitter } from 'tiny-typed-emitter'
 import { createEntriesStream } from './entries-stream.js'
 import { filePathMatchesFilter } from './utils.js'
 
-/** @import Hyperdrive from 'hyperdrive' */
 /** @import { BlobFilter } from '../types.js' */
+/** @import { THyperdriveIndex } from './hyperdrive-index.js' */
 
 /**
  * Like hyperdrive.download() but 'live', and for multiple drives.
@@ -26,7 +26,7 @@ import { filePathMatchesFilter } from './utils.js'
  * @extends {TypedEmitter<{ error: (error: Error) => void }>}
  */
 export class Downloader extends TypedEmitter {
-  /** @type {import('./index.js').THyperdriveIndex} */
+  /** @type {THyperdriveIndex} */
   #driveIndex
   /** @type {Set<{ done(): Promise<void>, destroy(): void }>} */
   #queuedDownloads = new Set()
@@ -36,7 +36,7 @@ export class Downloader extends TypedEmitter {
   #shouldDownloadFile
 
   /**
-   * @param {import('./index.js').THyperdriveIndex} driveIndex
+   * @param {THyperdriveIndex} driveIndex
    * @param {object} [options]
    * @param {BlobFilter | null} [options.filter] Filter blobs of specific types and/or sizes to download
    */

--- a/src/blob-store/entries-stream.js
+++ b/src/blob-store/entries-stream.js
@@ -5,12 +5,13 @@ import { noop } from '../utils.js'
 
 /** @import Hyperdrive from 'hyperdrive' */
 /** @import { BlobStoreEntriesStream } from '../types.js' */
+/** @import { THyperdriveIndex } from './hyperdrive-index.js' */
 
 const keyEncoding = new SubEncoder('files', 'utf-8')
 
 /**
  *
- * @param {import('./index.js').THyperdriveIndex} driveIndex
+ * @param {THyperdriveIndex} driveIndex
  * @param {object} opts
  * @param {boolean} [opts.live=false]
  * @returns {BlobStoreEntriesStream}

--- a/src/blob-store/hyperdrive-index.js
+++ b/src/blob-store/hyperdrive-index.js
@@ -1,0 +1,122 @@
+import b4a from 'b4a'
+import { discoveryKey } from 'hypercore-crypto'
+import Hyperdrive from 'hyperdrive'
+import util from 'node:util'
+import { TypedEmitter } from 'tiny-typed-emitter'
+
+/** @typedef {HyperdriveIndexImpl} THyperdriveIndex */
+
+/**
+ * @extends {TypedEmitter<{ 'add-drive': (drive: Hyperdrive) => void }>}
+ */
+export class HyperdriveIndexImpl extends TypedEmitter {
+  /** @type {Map<string, Hyperdrive>} */
+  #hyperdrives = new Map()
+  #writer
+  #writerKey
+  /** @param {import('../core-manager/index.js').CoreManager} coreManager */
+  constructor(coreManager) {
+    super()
+    /** @type {undefined | Hyperdrive} */
+    let writer
+    const corestore = new PretendCorestore({ coreManager })
+    const blobIndexCores = coreManager.getCores('blobIndex')
+    const writerCoreRecord = coreManager.getWriterCore('blobIndex')
+    this.#writerKey = writerCoreRecord.key
+    for (const { key } of blobIndexCores) {
+      // @ts-ignore - we know pretendCorestore is not actually a Corestore
+      const drive = new Hyperdrive(corestore, key)
+      // We use the discovery key to derive the id for a drive
+      this.#hyperdrives.set(getDiscoveryId(key), drive)
+      if (key.equals(this.#writerKey)) {
+        writer = drive
+      }
+    }
+    if (!writer) {
+      throw new Error('Could not find a writer for the blobIndex namespace')
+    }
+    this.#writer = writer
+
+    coreManager.on('add-core', ({ key, namespace }) => {
+      if (namespace !== 'blobIndex') return
+      // We use the discovery key to derive the id for a drive
+      const driveId = getDiscoveryId(key)
+      if (this.#hyperdrives.has(driveId)) return
+      // @ts-ignore - we know pretendCorestore is not actually a Corestore
+      const drive = new Hyperdrive(corestore, key)
+      this.#hyperdrives.set(driveId, drive)
+      this.emit('add-drive', drive)
+    })
+  }
+  get writer() {
+    return this.#writer
+  }
+  get writerKey() {
+    return this.#writerKey
+  }
+  [Symbol.iterator]() {
+    return this.#hyperdrives.values()
+  }
+  /** @param {string} driveId */
+  get(driveId) {
+    return this.#hyperdrives.get(driveId)
+  }
+}
+
+/**
+ * Implements the `get()` method as used by hyperdrive-next. It returns the
+ * relevant cores from the Mapeo CoreManager.
+ */
+class PretendCorestore {
+  #coreManager
+  /**
+   * @param {object} options
+   * @param {import('../core-manager/index.js').CoreManager} options.coreManager
+   */
+  constructor({ coreManager }) {
+    this.#coreManager = coreManager
+  }
+
+  /**
+   * @param {Buffer | { publicKey: Buffer } | { name: string }} opts
+   * @returns {import('hypercore')<"binary", Buffer> | undefined}
+   */
+  get(opts) {
+    if (b4a.isBuffer(opts)) {
+      opts = { publicKey: opts }
+    }
+    if ('key' in opts) {
+      // @ts-ignore
+      opts.publicKey = opts.key
+    }
+    if ('publicKey' in opts) {
+      // NB! We should always add blobIndex (Hyperbee) cores to the core manager
+      // before we use them here. We would only reach the addCore path if the
+      // blob core is read from the hyperbee header (before it is added to the
+      // core manager)
+      return (
+        this.#coreManager.getCoreByKey(opts.publicKey) ||
+        this.#coreManager.addCore(opts.publicKey, 'blob').core
+      )
+    } else if (opts.name === 'db') {
+      return this.#coreManager.getWriterCore('blobIndex').core
+    } else if (opts.name.includes('blobs')) {
+      return this.#coreManager.getWriterCore('blob').core
+    } else {
+      throw new Error(
+        'Unsupported corestore.get() with opts ' + util.inspect(opts)
+      )
+    }
+  }
+
+  /** no-op */
+  close() {}
+}
+
+/**
+ * @param {Buffer} key Public key of hypercore
+ * @returns {string} Hex-encoded string of derived discovery key
+ */
+function getDiscoveryId(key) {
+  return discoveryKey(key).toString('hex')
+}

--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -137,13 +137,7 @@ export class BlobStore extends TypedEmitter {
     const entriesStream = createEntriesStream(this.#driveIndex, { live })
     if (!filter) return entriesStream
     const filterStream = new FilterEntriesStream(filter)
-    const result = pipeline(entriesStream, filterStream, noop)
-    // Destroying the pipeline should destroy the *first* stream, not the
-    // whole pipeline.
-    Object.defineProperty(result, 'destroy', {
-      value: entriesStream.destroy.bind(entriesStream),
-    })
-    return result
+    return pipeline(entriesStream, filterStream, noop)
   }
 
   /**

--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -131,7 +131,7 @@ export class BlobStore extends TypedEmitter {
    * @param {object} opts
    * @param {boolean} [opts.live=false] Set to `true` to get a live stream of entries
    * @param {import('./utils.js').GenericBlobFilter | null} [opts.filter] Filter blob types and/or variants in returned entries. Filter is { [BlobType]: BlobVariants[] }.
-   * @returns
+   * @returns {BlobStoreEntriesStream}
    */
   createEntriesReadStream({ live = false, filter } = {}) {
     const entriesStream = createEntriesStream(this.#driveIndex, { live })

--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -137,7 +137,13 @@ export class BlobStore extends TypedEmitter {
     const entriesStream = createEntriesStream(this.#driveIndex, { live })
     if (!filter) return entriesStream
     const filterStream = new FilterEntriesStream(filter)
-    return pipeline(entriesStream, filterStream, noop)
+    const result = pipeline(entriesStream, filterStream, noop)
+    // Destroying the pipeline should destroy the *first* stream, not the
+    // whole pipeline.
+    Object.defineProperty(result, 'destroy', {
+      value: entriesStream.destroy.bind(entriesStream),
+    })
+    return result
   }
 
   /**

--- a/src/discovery/local-discovery.js
+++ b/src/discovery/local-discovery.js
@@ -9,6 +9,7 @@ import StartStopStateMachine from 'start-stop-state-machine'
 import pTimeout from 'p-timeout'
 import { keyToPublicId } from '@mapeo/crypto'
 import { Logger } from '../logger.js'
+import { getErrorCode } from '../lib/error.js'
 /** @import { OpenedNoiseStream } from '../lib/noise-secret-stream-helpers.js' */
 
 /** @typedef {{ publicKey: Buffer, secretKey: Buffer }} Keypair */
@@ -117,7 +118,7 @@ export class LocalDiscovery extends TypedEmitter {
 
     /** @param {Error} e */
     function onSocketError(e) {
-      if ('code' in e && e.code === 'EPIPE') {
+      if (getErrorCode(e) === 'EPIPE') {
         socket.destroy()
         if (secretStream) {
           secretStream.destroy()

--- a/src/fastify-plugins/maps.js
+++ b/src/fastify-plugins/maps.js
@@ -5,6 +5,7 @@ import { ReaderWatch, Server as SMPServerPlugin } from 'styled-map-package'
 
 import { noop } from '../utils.js'
 import { NotFoundError, ENOENTError } from './utils.js'
+import { getErrorCode } from '../lib/error.js'
 
 /** @import { FastifyPluginAsync } from 'fastify' */
 /** @import { Stats } from 'node:fs' */
@@ -56,7 +57,7 @@ export async function plugin(fastify, opts) {
       try {
         stats = await fs.stat(customMapPath)
       } catch (err) {
-        if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+        if (getErrorCode(err) === 'ENOENT') {
           throw new ENOENTError(customMapPath)
         }
 

--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -22,6 +22,30 @@ export class ErrorWithCode extends Error {
 }
 
 /**
+ * If the argument is an `Error` instance, return its `code` property if it is a string.
+ * Otherwise, returns `undefined`.
+ *
+ * @param {unknown} maybeError
+ * @returns {undefined | string}
+ * @example
+ * try {
+ *   // do something
+ * } catch (err) {
+ *   console.error(getErrorCode(err))
+ * }
+ */
+export function getErrorCode(maybeError) {
+  if (
+    maybeError instanceof Error &&
+    'code' in maybeError &&
+    typeof maybeError.code === 'string'
+  ) {
+    return maybeError.code
+  }
+  return undefined
+}
+
+/**
  * Get the error message from an object if possible.
  * Otherwise, stringify the argument.
  *

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -50,6 +50,7 @@ import { MemberApi } from './member-api.js'
 import {
   SyncApi,
   kHandleDiscoveryKey,
+  kSetBlobDownloadFilter,
   kWaitForInitialSyncWithPeer,
 } from './sync/sync-api.js'
 import { Logger } from './logger.js'
@@ -746,8 +747,8 @@ export class MapeoProject extends TypedEmitter {
     if (this.#isArchiveDevice === isArchiveDevice) return
     const blobDownloadFilter = getBlobDownloadFilter(isArchiveDevice)
     this.#blobStore.setDownloadFilter(blobDownloadFilter)
+    this.#syncApi[kSetBlobDownloadFilter](blobDownloadFilter)
     this.#isArchiveDevice = isArchiveDevice
-    // TODO: call this.#syncApi[kSetBlobDownloadFilter]()
   }
 
   /** @returns {boolean} */

--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -182,13 +182,23 @@ export class CoreSyncState {
    * blocks/ranges that are added here
    *
    * @param {PeerId} peerId
-   * @param {Array<{ start: number, length: number }>} ranges
+   * @param {number} start
+   * @param {number} length
+   * @returns {void}
    */
-  setPeerWants(peerId, ranges) {
+  addWantRange(peerId, start, length) {
     const peerState = this.#getOrCreatePeerState(peerId)
-    for (const { start, length } of ranges) {
-      peerState.setWantRange({ start, length })
-    }
+    peerState.addWantRange(start, length)
+    this.#update()
+  }
+
+  /**
+   * @param {PeerId} peerId
+   * @returns {void}
+   */
+  clearWantRanges(peerId) {
+    const peerState = this.#getOrCreatePeerState(peerId)
+    peerState.clearWantRanges()
     this.#update()
   }
 

--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -291,14 +291,13 @@ export class PeerState {
   #preHaves = new RemoteBitfield()
   /** @type {HypercoreRemoteBitfield | undefined} */
   #haves
-  /** @type {Bitfield} */
-  #wants = new RemoteBitfield()
+  /**
+   * What blocks do we want? If `null`, we want everything.
+   * @type {null | Bitfield}
+   */
+  #wants = null
   /** @type {PeerNamespaceState['status']} */
   status = 'stopped'
-  #wantAll
-  constructor({ wantAll = true } = {}) {
-    this.#wantAll = wantAll
-  }
   get preHavesBitfield() {
     return this.#preHaves
   }
@@ -316,17 +315,26 @@ export class PeerState {
     this.#haves = bitfield
   }
   /**
-   * Set a range of blocks that a peer wants. This is not part of the Hypercore
+   * Add a range of blocks that a peer wants. This is not part of the Hypercore
    * protocol, so we need our own extension messages that a peer can use to
    * inform us which blocks they are interested in. For most cores peers always
-   * want all blocks, but for blob cores often peers only want preview or
+   * want all blocks, but for blob cores peers may only want preview or
    * thumbnail versions of media
    *
-   * @param {{ start: number, length: number }} range
+   * @param {number} start
+   * @param {number} length
+   * @returns {void}
    */
-  setWantRange({ start, length }) {
-    this.#wantAll = false
+  addWantRange(start, length) {
+    this.#wants ??= new RemoteBitfield()
     this.#wants.setRange(start, length, true)
+  }
+  /**
+   * Set the range of blocks that this peer wants to the empty set. In other
+   * words, this peer wants nothing from this core.
+   */
+  clearWantRanges() {
+    this.#wants = new RemoteBitfield()
   }
   /**
    * Returns whether the peer has the block at `index`. If a pre-have bitfield
@@ -355,8 +363,7 @@ export class PeerState {
    * @param {number} index
    */
   want(index) {
-    if (this.#wantAll) return true
-    return this.#wants.get(index)
+    return this.#wants ? this.#wants.get(index) : true
   }
   /**
    * Return the "wants" for the 32 blocks from `index`, as a 32-bit integer
@@ -366,11 +373,10 @@ export class PeerState {
    * the 32 blocks from `index`
    */
   wantWord(index) {
-    if (this.#wantAll) {
-      // This is a 32-bit number with all bits set
-      return 2 ** 32 - 1
-    }
-    return getBitfieldWord(this.#wants, index)
+    return this.#wants
+      ? getBitfieldWord(this.#wants, index)
+      : // This is a 32-bit number with all bits set
+        2 ** 32 - 1
   }
 }
 

--- a/src/sync/namespace-sync-state.js
+++ b/src/sync/namespace-sync-state.js
@@ -137,6 +137,28 @@ export class NamespaceSyncState {
   }
 
   /**
+   * @param {string} peerId
+   * @param {number} start
+   * @param {number} length
+   * @returns {void}
+   */
+  addWantRange(peerId, start, length) {
+    for (const coreState of this.#coreStates.values()) {
+      coreState.addWantRange(peerId, start, length)
+    }
+  }
+
+  /**
+   * @param {string} peerId
+   * @returns {void}
+   */
+  clearWantRanges(peerId) {
+    for (const coreState of this.#coreStates.values()) {
+      coreState.clearWantRanges(peerId)
+    }
+  }
+
+  /**
    * @param {string} discoveryId
    */
   #getCoreState(discoveryId) {

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -26,6 +26,8 @@ export const kWaitForInitialSyncWithPeer = Symbol(
   'wait for initial sync with peer'
 )
 export const kSetBlobDownloadFilter = Symbol('set isArchiveDevice')
+export const kAddBlobWantRange = Symbol('add blob want range')
+export const kClearBlobWantRanges = Symbol('clear blob want ranges')
 
 /**
  * @typedef {'initial' | 'full'} SyncType
@@ -161,6 +163,28 @@ export class SyncApi extends TypedEmitter {
     for (const peer of this.#coreManager.creatorCore.peers) {
       this.#coreManager.sendDownloadIntents(blobDownloadFilter, peer)
     }
+  }
+
+  /**
+   * Add some blob blocks this peer wants.
+   *
+   * @param {string} peerId
+   * @param {number} start
+   * @param {number} length
+   * @returns {void}
+   */
+  [kAddBlobWantRange](peerId, start, length) {
+    this[kSyncState].addBlobWantRange(peerId, start, length)
+  }
+
+  /**
+   * Clear the blob blocks this peer wants.
+   *
+   * @param {string} peerId
+   * @returns {void}
+   */
+  [kClearBlobWantRanges](peerId) {
+    this[kSyncState].clearBlobWantRanges(peerId)
   }
 
   /** @type {import('../local-peers.js').LocalPeersEvents['discovery-key']} */

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -16,7 +16,7 @@ import { NO_ROLE_ID } from '../roles.js'
 /** @import * as http from 'node:http' */
 /** @import { CoreOwnership } from '../core-ownership.js' */
 /** @import { OpenedNoiseStream } from '../lib/noise-secret-stream-helpers.js' */
-/** @import { ReplicationStream } from '../types.js' */
+/** @import { BlobFilter, ReplicationStream } from '../types.js' */
 
 export const kHandleDiscoveryKey = Symbol('handle discovery key')
 export const kSyncState = Symbol('sync state')
@@ -91,7 +91,8 @@ export class SyncApi extends TypedEmitter {
   #getReplicationStream
   /** @type {Map<string, WebSocket>} */
   #serverWebsockets = new Map()
-  #blobDownloadFilter
+  /** @type {null | BlobFilter} */
+  #blobDownloadFilter = null
 
   /**
    * @param {object} opts
@@ -100,7 +101,7 @@ export class SyncApi extends TypedEmitter {
    * @param {import('../roles.js').Roles} opts.roles
    * @param {() => Promise<Iterable<string>>} opts.getServerWebsocketUrls
    * @param {() => ReplicationStream} opts.getReplicationStream
-   * @param {import('../types.js').BlobFilter | null} opts.blobDownloadFilter
+   * @param {null | BlobFilter} opts.blobDownloadFilter
    * @param {number} [opts.throttleMs]
    * @param {Logger} [opts.logger]
    */
@@ -116,7 +117,6 @@ export class SyncApi extends TypedEmitter {
   }) {
     super()
     this.#l = Logger.create('syncApi', logger)
-    this.#blobDownloadFilter = blobDownloadFilter
     this.#coreManager = coreManager
     this.#coreOwnership = coreOwnership
     this.#roles = roles
@@ -132,6 +132,8 @@ export class SyncApi extends TypedEmitter {
     this[kSyncState].on('state', (namespaceSyncState) => {
       this.#updateState(namespaceSyncState)
     })
+
+    this[kSetBlobDownloadFilter](blobDownloadFilter)
 
     this.#coreManager.creatorCore.on('peer-add', this.#handlePeerAdd)
     this.#coreManager.creatorCore.on('peer-remove', this.#handlePeerDisconnect)

--- a/src/sync/sync-state.js
+++ b/src/sync/sync-state.js
@@ -68,6 +68,24 @@ export class SyncState extends TypedEmitter {
     ])
   }
 
+  /**
+   * @param {string} peerId
+   * @param {number} start
+   * @param {number} length
+   * @returns {void}
+   */
+  addBlobWantRange(peerId, start, length) {
+    this.#syncStates.blob.addWantRange(peerId, start, length)
+  }
+
+  /**
+   * @param {string} peerId
+   * @returns {void}
+   */
+  clearBlobWantRanges(peerId) {
+    this.#syncStates.blob.clearWantRanges(peerId)
+  }
+
   #handleUpdate = () => {
     this.emit('state', this.getState())
   }

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test, { describe } from 'node:test'
-import { ErrorWithCode, getErrorMessage } from '../../src/lib/error.js'
+import {
+  ErrorWithCode,
+  getErrorCode,
+  getErrorMessage,
+} from '../../src/lib/error.js'
 
 describe('ErrorWithCode', () => {
   test('ErrorWithCode with two arguments', () => {
@@ -19,6 +23,44 @@ describe('ErrorWithCode', () => {
     assert.equal(err.message, 'my message')
     assert.equal(err.cause, otherError)
     assert(err instanceof Error)
+  })
+})
+
+describe('getErrorCode', () => {
+  test('from values without a string code', () => {
+    class ErrorWithNumericCode extends Error {
+      code = 123
+    }
+
+    const testCases = [
+      undefined,
+      null,
+      'ignored',
+      { code: 'ignored' },
+      new Error('has no code'),
+      new ErrorWithNumericCode(),
+    ]
+
+    for (const testCase of testCases) {
+      assert.equal(getErrorCode(testCase), undefined)
+    }
+  })
+
+  test('from Errors with a string code', () => {
+    class ErrorWithInheritedCode extends Error {
+      get code() {
+        return 'foo'
+      }
+    }
+
+    const testCases = [
+      new ErrorWithCode('foo', 'message'),
+      new ErrorWithInheritedCode(),
+    ]
+
+    for (const testCase of testCases) {
+      assert.equal(getErrorCode(testCase), 'foo')
+    }
   })
 })
 

--- a/test/sync/core-sync-state.js
+++ b/test/sync/core-sync-state.js
@@ -408,7 +408,7 @@ function createState({ have, prehave, want, status }) {
     // 53 because the max safe integer in JS is 53 bits
     for (let i = 0; i < 53; i++) {
       if ((bigInt >> BigInt(i)) & BigInt(1)) {
-        peerState.setWantRange({ start: i, length: 1 })
+        peerState.addWantRange(i, 1)
       }
     }
   }
@@ -480,16 +480,14 @@ async function downloadCore(core, bits) {
 function setPeerWants(state, peerId, bits) {
   if (typeof bits === 'undefined') return
   if (bits > Number.MAX_SAFE_INTEGER) throw new Error()
+  state.clearWantRanges(peerId)
   const bigInt = BigInt(bits)
-  /** @type {{ start: number, length: number}[]} */
-  const ranges = []
   // 53 because the max safe integer in JS is 53 bits
   for (let i = 0; i < 53; i++) {
     if ((bigInt >> BigInt(i)) & BigInt(1)) {
-      ranges.push({ start: i, length: 1 })
+      state.addWantRange(peerId, i, 1)
     }
   }
-  state.setPeerWants(peerId, ranges)
 }
 
 /**


### PR DESCRIPTION
*I recommend [reviewing this PR one commit at a time](https://github.com/digidem/comapeo-core/pull/956/commits).*

When you receive a blob filter from another peer, this updates their sync states. For example, if you receive a blob filter that says "I only want photo thumbnails", that peer's "wants" bitfield will be reduced.

Closes #682 and #905.