### PR TITLE
fix: only the project creator can change their role

### DIFF
--- a/src/roles.js
+++ b/src/roles.js
@@ -403,7 +403,7 @@ export class Roles extends TypedEmitter {
     }
   }
 
-  async #isProjectCreator() {
+  #isProjectCreator() {
     const ownAuthCoreId = this.#coreManager
       .getWriterCore('auth')
       .key.toString('hex')


### PR DESCRIPTION
(This diff looks large, but it's just one line of source code and a bunch of tests.)

We have some code like this:

```javascript
if (isAssigningProjectCreatorRole && !this.#isProjectCreator()) {
```

The intent: only allow the project creator to change their own role.

However, `this.#isProjectCreator` returned a `Promise`, which meant that the second part of the condition *always* evaluated to `false`, which meant that the whole condition always evaluated to false, which meant that non-creators could change the creator's role.

This fixes that by making `#isProjectCreator` return a `boolean`, not `Promise<boolean>`.

Found this while working on #188.