### PR TITLE
test: assert correct number of connected devices

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -855,6 +855,12 @@ test('Correct sync state prior to data sync', async function (t) {
     managers.map((m) => m.getProject(projectId))
   )
 
+  for (const project of projects) {
+    const { remoteDeviceSyncState } = project.$sync.getState()
+    const otherDeviceCount = Object.keys(remoteDeviceSyncState).length
+    assert.equal(otherDeviceCount, COUNT - 1)
+  }
+
   const generated = await seedDatabases(projects, { schemas: ['observation'] })
   await waitForSync(projects, 'initial')
 


### PR DESCRIPTION
In #872, we observed a bug where we seemingly had the wrong number of remote sync states. This adds a test assertion that we have the right number.

I plan to YOLO-merge this if CI passes.