### PR TITLE
chore: remove unnecessary `prettier-ignore` directive

### DIFF
--- a/src/core-ownership.js
+++ b/src/core-ownership.js
@@ -86,7 +86,6 @@ export class CoreOwnership extends TypedEmitter {
     for (const namespace of NAMESPACES) {
       expressions.push(eq(table[`${namespace}CoreId`], coreId))
     }
-    // prettier-ignore
     const result = (await this.#dataType[kSelect]())
       .where(or.apply(null, expressions))
       .get()


### PR DESCRIPTION
This change should have no user impact.

This directive wasn't doing anything, so we can remove it.

I plan to YOLO-merge this change.