### PR TITLE
chore: update type-fest to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "sub-encoder": "^2.1.1",
         "throttle-debounce": "^5.0.0",
         "tiny-typed-emitter": "^2.1.0",
-        "type-fest": "^4.5.0",
+        "type-fest": "^4.30.0",
         "undici": "^6.13.0",
         "unix-path-resolve": "^1.0.2",
         "varint": "^6.0.0",
@@ -9547,9 +9547,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
-      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
+      "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "sub-encoder": "^2.1.1",
     "throttle-debounce": "^5.0.0",
     "tiny-typed-emitter": "^2.1.0",
-    "type-fest": "^4.5.0",
+    "type-fest": "^4.30.0",
     "undici": "^6.13.0",
     "unix-path-resolve": "^1.0.2",
     "varint": "^6.0.0",

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -739,12 +739,14 @@ export class MapeoManager extends TypedEmitter {
     )
 
     if (deviceInfo.deviceType !== 'selfHostedServer') {
+      /** @type {RPCDeviceType} */
+      const deviceType = deviceInfo.deviceType
       // We have to make a copy of this because TypeScript can't guarantee that
       // `deviceInfo` won't be mutated by the time it gets to the
       // `sendDeviceInfo` call below.
       const deviceInfoToSend = {
         ...deviceInfo,
-        deviceType: deviceInfo.deviceType,
+        deviceType,
       }
       await Promise.all(
         this.#localPeers.peers


### PR DESCRIPTION
This updates `type-fest` to the latest version, 4.30.0. A small change was required in `src/mapeo-manager.js` to fix a TypeScript error, but this should have no impact on functionality.

I plan to YOLO-merge this if CI passes.