### PR TITLE
chore: update `@comapeo/schema` to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "1.2.0",
+        "@comapeo/schema": "1.3.0",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",
@@ -332,6 +332,19 @@
         "yauzl-promise": "^4.0.0"
       }
     },
+    "node_modules/@comapeo/core/node_modules/@comapeo/schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.2.0.tgz",
+      "integrity": "sha512-LWrUSqtXmrEmE/B9V/zffKBbJmMo37AlvjXczvGx1+BbCAjOYCPDX6GCtnSKNsvtnNS2KQZDm9apg3mp92tFGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@comapeo/geometry": "^1.0.2",
+        "compact-encoding": "^2.12.0",
+        "protobufjs": "^7.2.5",
+        "type-fest": "^4.26.0"
+      }
+    },
     "node_modules/@comapeo/core2.0.1": {
       "name": "@comapeo/core",
       "version": "2.0.1",
@@ -405,19 +418,21 @@
       "integrity": "sha512-6wLTtBOdlwtYMyrynBq6ZQ7S1aVABXQSwR/1QENkFkc7WyLLs4wLd9ny7WfSUQdHn6E2zfvA7WfKH7R06Zy3gQ=="
     },
     "node_modules/@comapeo/geometry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.0.2.tgz",
-      "integrity": "sha512-q6zadJA3lr85GZPTZ+lol9F6ERRq2Rt4upON7HhcwPPBiCLN696SY03OJZCE6xkXHxjJY98FF5DxVX3W0IftLQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.1.0.tgz",
+      "integrity": "sha512-lECdtW7Etcjt9D8C64Qpc0sIMWcuKXmmLJA7c3S06BzliBFS6DtEnZnm7MzJtPf20ASzkdd/+ACOWIxo/draPw==",
+      "license": "MIT",
       "dependencies": {
         "protobufjs": "^7.4.0"
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.2.0.tgz",
-      "integrity": "sha512-LWrUSqtXmrEmE/B9V/zffKBbJmMo37AlvjXczvGx1+BbCAjOYCPDX6GCtnSKNsvtnNS2KQZDm9apg3mp92tFGA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.3.0.tgz",
+      "integrity": "sha512-+rDgfKahCbUk5bU6BBcCQ3aMSRJfenkbYET0PdN4sg2c+G3BOELaTI5+s5n+oZQEEOxYXp3UDkT61PlA2nUPQw==",
+      "license": "MIT",
       "dependencies": {
-        "@comapeo/geometry": "^1.0.2",
+        "@comapeo/geometry": "^1.1.0",
         "compact-encoding": "^2.12.0",
         "protobufjs": "^7.2.5",
         "type-fest": "^4.26.0"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "1.2.0",
+    "@comapeo/schema": "1.3.0",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",


### PR DESCRIPTION
This is necessary for <https://github.com/digidem/comapeo-cloud/pull/36>.

I plan to YOLO-merge this if CI passes.