### PR TITLE
chore: update native deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2795,11 +2795,21 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/crc-universal": {
-      "version": "1.0.2",
-      "license": "ISC",
+    "node_modules/crc-native": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/crc-native/-/crc-native-1.1.5.tgz",
+      "integrity": "sha512-toSzpisZ2AhmmfTA6h2Lt0JWOM6G+y0wAGP+JL9bkmLvwpWV2Co4P+DhGEOcGabIeFORZmfIvEs7VAm7kma5vg==",
+      "optional": true,
       "dependencies": {
-        "node-gyp-build": "^4.5.0"
+        "node-gyp-build": "^4.8.2"
+      }
+    },
+    "node_modules/crc-universal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/crc-universal/-/crc-universal-1.0.4.tgz",
+      "integrity": "sha512-CE9xWEI6Gd5V0Bdmj5NoWH3d7+EIe4zUpy1sv6uvKYznzsDP1vhiWsTBmL6q9IrH2P6RRshp+8AkhR4CMtY5Hg==",
+      "optionalDependencies": {
+        "crc-native": "^1.0.3"
       }
     },
     "node_modules/crc32-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4398,13 +4398,13 @@
       "license": "MIT"
     },
     "node_modules/fs-native-extensions": {
-      "version": "1.1.0",
-      "hasInstallScript": true,
-      "license": "ISC",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.3.2.tgz",
+      "integrity": "sha512-fQaLJt4uY96iiMdy+rV561TaXefkfTq4dmSXcN2D1z8SBtFTsmcO3GaJexPKTxltqdh826JQBK1CySo3EpzgQQ==",
       "optional": true,
       "dependencies": {
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build": "^4.8.2",
+        "which-runtime": "^1.2.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -6692,11 +6692,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/napi-macros": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -6741,9 +6736,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -7864,15 +7859,13 @@
       }
     },
     "node_modules/quickbit-native": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.2.0.tgz",
-      "integrity": "sha512-/C5EOMP9Kyk+P7Z0+ipedppwhMkPA0SBj31Hk8xZQ/0rfKPLlafYJcxr+H942eIQ60xRif9c18B9OV0REfCWzg==",
-      "hasInstallScript": true,
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/quickbit-native/-/quickbit-native-2.3.4.tgz",
+      "integrity": "sha512-inl+SbEDqL+NTGFsk/S7nhaFtNEUANpXM1umGeJdOY0gtCLcDTSOZ9sGIXcaKukBgThw9cTD1rgCsYy6sAox+A==",
       "optional": true,
       "dependencies": {
         "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build": "^4.8.2"
       }
     },
     "node_modules/quickbit-universal": {
@@ -8720,14 +8713,13 @@
       "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/simdle-native": {
-      "version": "1.1.3",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/simdle-native/-/simdle-native-1.3.4.tgz",
+      "integrity": "sha512-7fWq9N5wP3ZYdiBcdjdNFHQ+kU/+rxr785HbxMmFjEb8choPbgE9p4fJ5Nm/H2rpSyVkgY9j0E9hYY1RAvBg+A==",
       "optional": true,
       "dependencies": {
         "b4a": "^1.6.0",
-        "napi-macros": "^2.0.0",
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build": "^4.8.2"
       }
     },
     "node_modules/simdle-universal": {
@@ -8870,12 +8862,11 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.4.tgz",
-      "integrity": "sha512-faqOKw4WQKK7r/ybn6Lqo1F9+L5T6NlBJJYvpxbZPetpWylUVqz449mvlwIBKBqxEHbWakWuOlUt8J3Qpc4sWw==",
-      "hasInstallScript": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "dependencies": {
-        "node-gyp-build": "^4.6.0"
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/sodium-secretstream": {
@@ -10146,6 +10137,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.2.1.tgz",
+      "integrity": "sha512-8feIHccQFH/whiA1fD1b4c5+Q7T4ry1g1oHYc2mHnFh81tTQFsCvy3zhS2geUapkFAVBddUT/AM1a3rbqJweFg==",
+      "optional": true
     },
     "node_modules/which-typed-array": {
       "version": "1.1.11",


### PR DESCRIPTION
Update holepunch native dependencies to the latest semver compatible versions. None of these are direct dependencies, this only changes package-lock.json. Updating them ensures that we are running tests with the same native dependencies that might be used by the consumer of this module. (it doesn't guarantee it however - we need to shrinkwrap this module to guarantee  that).
