### PR TITLE
fix: fix non-archive device sync progress

### DIFF
--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -307,7 +307,10 @@ test('non-archive devices only sync a subset of blobs', async (t) => {
     blobMetadata({ mimeType: 'image/jpeg' })
   )
 
-  await waitForSync(projects, 'full')
+  // Wait to ensure sync metadata is sent first
+  await delay(200)
+
+  await pTimeout(waitForSync(projects, 'full'), { milliseconds: 1000 })
 
   await Promise.all([
     assert404({ ...photoBlob2, variant: 'original' }),


### PR DESCRIPTION
We have been seeing flakey tests for a while for this test, and I think the issue is actually that the code has a bug, and the test is only occassionally exposing it. This PR currently only includes changes to the e2e tests to attempt to more reliably replicate the bug.