### PR TITLE
chore(ci): update docs workflow to fix deprecation error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,9 @@ jobs:
           npm run doc:publish
       - id: upload-documentation
         name: Upload documentation to Pages
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/api/html
       - id: deployment
         name: Deploy documentation to GitHub Pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
The docs workflow is currently broken due to our version of `upload-pages-artifact` that uses a deprecated version of the `upload-artifact` action. Updating this action requires us to use a new version of the `deploy-pages` action as well.

Used https://github.com/suzuki-shunsuke/pinact to update the relevant actions to the exact SHA hashes as opposed to using git tags, which has better security implications. Happy to update the other actions in this workflow to do the same if desired.