### PR TITLE
Feat: RPC acknowledgements, add role after project details are sent

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -39,6 +39,27 @@ message DeviceInfo {
     tablet = 2;
     desktop = 3;
   }
+  enum RPCFeatures {
+    features_unspecified = 0;
+    ack = 1;
+  }
   string name = 1;
   optional DeviceType deviceType = 2;
+  repeated RPCFeatures features = 3;
+}
+
+message InviteAck {
+  bytes inviteId = 1;
+}
+
+message InviteCancelAck {
+  bytes inviteId = 1;
+}
+
+message InviteResponseAck {
+  bytes inviteId = 1;
+}
+
+message ProjectJoinDetailsAck {
+  bytes inviteId = 1;
 }

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -33,6 +33,7 @@ export interface ProjectJoinDetails {
 export interface DeviceInfo {
     name: string;
     deviceType?: DeviceInfo_DeviceType | undefined;
+    features: DeviceInfo_RPCFeatures[];
 }
 export declare const DeviceInfo_DeviceType: {
     readonly device_type_unspecified: "device_type_unspecified";
@@ -44,6 +45,26 @@ export declare const DeviceInfo_DeviceType: {
 export type DeviceInfo_DeviceType = typeof DeviceInfo_DeviceType[keyof typeof DeviceInfo_DeviceType];
 export declare function deviceInfo_DeviceTypeFromJSON(object: any): DeviceInfo_DeviceType;
 export declare function deviceInfo_DeviceTypeToNumber(object: DeviceInfo_DeviceType): number;
+export declare const DeviceInfo_RPCFeatures: {
+    readonly features_unspecified: "features_unspecified";
+    readonly ack: "ack";
+    readonly UNRECOGNIZED: "UNRECOGNIZED";
+};
+export type DeviceInfo_RPCFeatures = typeof DeviceInfo_RPCFeatures[keyof typeof DeviceInfo_RPCFeatures];
+export declare function deviceInfo_RPCFeaturesFromJSON(object: any): DeviceInfo_RPCFeatures;
+export declare function deviceInfo_RPCFeaturesToNumber(object: DeviceInfo_RPCFeatures): number;
+export interface InviteAck {
+    inviteId: Buffer;
+}
+export interface InviteCancelAck {
+    inviteId: Buffer;
+}
+export interface InviteResponseAck {
+    inviteId: Buffer;
+}
+export interface ProjectJoinDetailsAck {
+    inviteId: Buffer;
+}
 export declare const Invite: {
     encode(message: Invite, writer?: _m0.Writer): _m0.Writer;
     decode(input: _m0.Reader | Uint8Array, length?: number): Invite;
@@ -73,6 +94,30 @@ export declare const DeviceInfo: {
     decode(input: _m0.Reader | Uint8Array, length?: number): DeviceInfo;
     create<I extends Exact<DeepPartial<DeviceInfo>, I>>(base?: I): DeviceInfo;
     fromPartial<I extends Exact<DeepPartial<DeviceInfo>, I>>(object: I): DeviceInfo;
+};
+export declare const InviteAck: {
+    encode(message: InviteAck, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): InviteAck;
+    create<I extends Exact<DeepPartial<InviteAck>, I>>(base?: I): InviteAck;
+    fromPartial<I extends Exact<DeepPartial<InviteAck>, I>>(object: I): InviteAck;
+};
+export declare const InviteCancelAck: {
+    encode(message: InviteCancelAck, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): InviteCancelAck;
+    create<I extends Exact<DeepPartial<InviteCancelAck>, I>>(base?: I): InviteCancelAck;
+    fromPartial<I extends Exact<DeepPartial<InviteCancelAck>, I>>(object: I): InviteCancelAck;
+};
+export declare const InviteResponseAck: {
+    encode(message: InviteResponseAck, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): InviteResponseAck;
+    create<I extends Exact<DeepPartial<InviteResponseAck>, I>>(base?: I): InviteResponseAck;
+    fromPartial<I extends Exact<DeepPartial<InviteResponseAck>, I>>(object: I): InviteResponseAck;
+};
+export declare const ProjectJoinDetailsAck: {
+    encode(message: ProjectJoinDetailsAck, writer?: _m0.Writer): _m0.Writer;
+    decode(input: _m0.Reader | Uint8Array, length?: number): ProjectJoinDetailsAck;
+    create<I extends Exact<DeepPartial<ProjectJoinDetailsAck>, I>>(base?: I): ProjectJoinDetailsAck;
+    fromPartial<I extends Exact<DeepPartial<ProjectJoinDetailsAck>, I>>(object: I): ProjectJoinDetailsAck;
 };
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 type DeepPartial<T> = T extends Builtin ? T : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> : T extends {} ? {

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -85,6 +85,36 @@ export function deviceInfo_DeviceTypeToNumber(object) {
             return -1;
     }
 }
+export var DeviceInfo_RPCFeatures = {
+    features_unspecified: "features_unspecified",
+    ack: "ack",
+    UNRECOGNIZED: "UNRECOGNIZED",
+};
+export function deviceInfo_RPCFeaturesFromJSON(object) {
+    switch (object) {
+        case 0:
+        case "features_unspecified":
+            return DeviceInfo_RPCFeatures.features_unspecified;
+        case 1:
+        case "ack":
+            return DeviceInfo_RPCFeatures.ack;
+        case -1:
+        case "UNRECOGNIZED":
+        default:
+            return DeviceInfo_RPCFeatures.UNRECOGNIZED;
+    }
+}
+export function deviceInfo_RPCFeaturesToNumber(object) {
+    switch (object) {
+        case DeviceInfo_RPCFeatures.features_unspecified:
+            return 0;
+        case DeviceInfo_RPCFeatures.ack:
+            return 1;
+        case DeviceInfo_RPCFeatures.UNRECOGNIZED:
+        default:
+            return -1;
+    }
+}
 function createBaseInvite() {
     return { inviteId: Buffer.alloc(0), projectInviteId: Buffer.alloc(0), projectName: "", invitorName: "" };
 }
@@ -336,7 +366,7 @@ export var ProjectJoinDetails = {
     },
 };
 function createBaseDeviceInfo() {
-    return { name: "" };
+    return { name: "", features: [] };
 }
 export var DeviceInfo = {
     encode: function (message, writer) {
@@ -347,6 +377,12 @@ export var DeviceInfo = {
         if (message.deviceType !== undefined) {
             writer.uint32(16).int32(deviceInfo_DeviceTypeToNumber(message.deviceType));
         }
+        writer.uint32(26).fork();
+        for (var _i = 0, _a = message.features; _i < _a.length; _i++) {
+            var v = _a[_i];
+            writer.int32(deviceInfo_RPCFeaturesToNumber(v));
+        }
+        writer.ldelim();
         return writer;
     },
     decode: function (input, length) {
@@ -368,6 +404,19 @@ export var DeviceInfo = {
                     }
                     message.deviceType = deviceInfo_DeviceTypeFromJSON(reader.int32());
                     continue;
+                case 3:
+                    if (tag === 24) {
+                        message.features.push(deviceInfo_RPCFeaturesFromJSON(reader.int32()));
+                        continue;
+                    }
+                    if (tag === 26) {
+                        var end2 = reader.uint32() + reader.pos;
+                        while (reader.pos < end2) {
+                            message.features.push(deviceInfo_RPCFeaturesFromJSON(reader.int32()));
+                        }
+                        continue;
+                    }
+                    break;
             }
             if ((tag & 7) === 4 || tag === 0) {
                 break;
@@ -380,10 +429,179 @@ export var DeviceInfo = {
         return DeviceInfo.fromPartial(base !== null && base !== void 0 ? base : {});
     },
     fromPartial: function (object) {
-        var _a, _b;
+        var _a, _b, _c;
         var message = createBaseDeviceInfo();
         message.name = (_a = object.name) !== null && _a !== void 0 ? _a : "";
         message.deviceType = (_b = object.deviceType) !== null && _b !== void 0 ? _b : undefined;
+        message.features = ((_c = object.features) === null || _c === void 0 ? void 0 : _c.map(function (e) { return e; })) || [];
+        return message;
+    },
+};
+function createBaseInviteAck() {
+    return { inviteId: Buffer.alloc(0) };
+}
+export var InviteAck = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.inviteId.length !== 0) {
+            writer.uint32(10).bytes(message.inviteId);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInviteAck();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.inviteId = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+    create: function (base) {
+        return InviteAck.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInviteAck();
+        message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        return message;
+    },
+};
+function createBaseInviteCancelAck() {
+    return { inviteId: Buffer.alloc(0) };
+}
+export var InviteCancelAck = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.inviteId.length !== 0) {
+            writer.uint32(10).bytes(message.inviteId);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInviteCancelAck();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.inviteId = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+    create: function (base) {
+        return InviteCancelAck.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInviteCancelAck();
+        message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        return message;
+    },
+};
+function createBaseInviteResponseAck() {
+    return { inviteId: Buffer.alloc(0) };
+}
+export var InviteResponseAck = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.inviteId.length !== 0) {
+            writer.uint32(10).bytes(message.inviteId);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseInviteResponseAck();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.inviteId = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+    create: function (base) {
+        return InviteResponseAck.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseInviteResponseAck();
+        message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
+        return message;
+    },
+};
+function createBaseProjectJoinDetailsAck() {
+    return { inviteId: Buffer.alloc(0) };
+}
+export var ProjectJoinDetailsAck = {
+    encode: function (message, writer) {
+        if (writer === void 0) { writer = _m0.Writer.create(); }
+        if (message.inviteId.length !== 0) {
+            writer.uint32(10).bytes(message.inviteId);
+        }
+        return writer;
+    },
+    decode: function (input, length) {
+        var reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+        var end = length === undefined ? reader.len : reader.pos + length;
+        var message = createBaseProjectJoinDetailsAck();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+                case 1:
+                    if (tag !== 10) {
+                        break;
+                    }
+                    message.inviteId = reader.bytes();
+                    continue;
+            }
+            if ((tag & 7) === 4 || tag === 0) {
+                break;
+            }
+            reader.skipType(tag & 7);
+        }
+        return message;
+    },
+    create: function (base) {
+        return ProjectJoinDetailsAck.fromPartial(base !== null && base !== void 0 ? base : {});
+    },
+    fromPartial: function (object) {
+        var _a;
+        var message = createBaseProjectJoinDetailsAck();
+        message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
         return message;
     },
 };

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -76,6 +76,7 @@ export interface ProjectJoinDetails {
 export interface DeviceInfo {
   name: string;
   deviceType?: DeviceInfo_DeviceType | undefined;
+  features: DeviceInfo_RPCFeatures[];
 }
 
 export const DeviceInfo_DeviceType = {
@@ -123,6 +124,57 @@ export function deviceInfo_DeviceTypeToNumber(object: DeviceInfo_DeviceType): nu
     default:
       return -1;
   }
+}
+
+export const DeviceInfo_RPCFeatures = {
+  features_unspecified: "features_unspecified",
+  ack: "ack",
+  UNRECOGNIZED: "UNRECOGNIZED",
+} as const;
+
+export type DeviceInfo_RPCFeatures = typeof DeviceInfo_RPCFeatures[keyof typeof DeviceInfo_RPCFeatures];
+
+export function deviceInfo_RPCFeaturesFromJSON(object: any): DeviceInfo_RPCFeatures {
+  switch (object) {
+    case 0:
+    case "features_unspecified":
+      return DeviceInfo_RPCFeatures.features_unspecified;
+    case 1:
+    case "ack":
+      return DeviceInfo_RPCFeatures.ack;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return DeviceInfo_RPCFeatures.UNRECOGNIZED;
+  }
+}
+
+export function deviceInfo_RPCFeaturesToNumber(object: DeviceInfo_RPCFeatures): number {
+  switch (object) {
+    case DeviceInfo_RPCFeatures.features_unspecified:
+      return 0;
+    case DeviceInfo_RPCFeatures.ack:
+      return 1;
+    case DeviceInfo_RPCFeatures.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+export interface InviteAck {
+  inviteId: Buffer;
+}
+
+export interface InviteCancelAck {
+  inviteId: Buffer;
+}
+
+export interface InviteResponseAck {
+  inviteId: Buffer;
+}
+
+export interface ProjectJoinDetailsAck {
+  inviteId: Buffer;
 }
 
 function createBaseInvite(): Invite {
@@ -396,7 +448,7 @@ export const ProjectJoinDetails = {
 };
 
 function createBaseDeviceInfo(): DeviceInfo {
-  return { name: "" };
+  return { name: "", features: [] };
 }
 
 export const DeviceInfo = {
@@ -407,6 +459,11 @@ export const DeviceInfo = {
     if (message.deviceType !== undefined) {
       writer.uint32(16).int32(deviceInfo_DeviceTypeToNumber(message.deviceType));
     }
+    writer.uint32(26).fork();
+    for (const v of message.features) {
+      writer.int32(deviceInfo_RPCFeaturesToNumber(v));
+    }
+    writer.ldelim();
     return writer;
   },
 
@@ -431,6 +488,23 @@ export const DeviceInfo = {
 
           message.deviceType = deviceInfo_DeviceTypeFromJSON(reader.int32());
           continue;
+        case 3:
+          if (tag === 24) {
+            message.features.push(deviceInfo_RPCFeaturesFromJSON(reader.int32()));
+
+            continue;
+          }
+
+          if (tag === 26) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.features.push(deviceInfo_RPCFeaturesFromJSON(reader.int32()));
+            }
+
+            continue;
+          }
+
+          break;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -447,6 +521,187 @@ export const DeviceInfo = {
     const message = createBaseDeviceInfo();
     message.name = object.name ?? "";
     message.deviceType = object.deviceType ?? undefined;
+    message.features = object.features?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBaseInviteAck(): InviteAck {
+  return { inviteId: Buffer.alloc(0) };
+}
+
+export const InviteAck = {
+  encode(message: InviteAck, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.inviteId.length !== 0) {
+      writer.uint32(10).bytes(message.inviteId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): InviteAck {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInviteAck();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.inviteId = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<InviteAck>, I>>(base?: I): InviteAck {
+    return InviteAck.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InviteAck>, I>>(object: I): InviteAck {
+    const message = createBaseInviteAck();
+    message.inviteId = object.inviteId ?? Buffer.alloc(0);
+    return message;
+  },
+};
+
+function createBaseInviteCancelAck(): InviteCancelAck {
+  return { inviteId: Buffer.alloc(0) };
+}
+
+export const InviteCancelAck = {
+  encode(message: InviteCancelAck, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.inviteId.length !== 0) {
+      writer.uint32(10).bytes(message.inviteId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): InviteCancelAck {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInviteCancelAck();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.inviteId = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<InviteCancelAck>, I>>(base?: I): InviteCancelAck {
+    return InviteCancelAck.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InviteCancelAck>, I>>(object: I): InviteCancelAck {
+    const message = createBaseInviteCancelAck();
+    message.inviteId = object.inviteId ?? Buffer.alloc(0);
+    return message;
+  },
+};
+
+function createBaseInviteResponseAck(): InviteResponseAck {
+  return { inviteId: Buffer.alloc(0) };
+}
+
+export const InviteResponseAck = {
+  encode(message: InviteResponseAck, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.inviteId.length !== 0) {
+      writer.uint32(10).bytes(message.inviteId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): InviteResponseAck {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseInviteResponseAck();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.inviteId = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<InviteResponseAck>, I>>(base?: I): InviteResponseAck {
+    return InviteResponseAck.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<InviteResponseAck>, I>>(object: I): InviteResponseAck {
+    const message = createBaseInviteResponseAck();
+    message.inviteId = object.inviteId ?? Buffer.alloc(0);
+    return message;
+  },
+};
+
+function createBaseProjectJoinDetailsAck(): ProjectJoinDetailsAck {
+  return { inviteId: Buffer.alloc(0) };
+}
+
+export const ProjectJoinDetailsAck = {
+  encode(message: ProjectJoinDetailsAck, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.inviteId.length !== 0) {
+      writer.uint32(10).bytes(message.inviteId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ProjectJoinDetailsAck {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseProjectJoinDetailsAck();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.inviteId = reader.bytes() as Buffer;
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  create<I extends Exact<DeepPartial<ProjectJoinDetailsAck>, I>>(base?: I): ProjectJoinDetailsAck {
+    return ProjectJoinDetailsAck.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ProjectJoinDetailsAck>, I>>(object: I): ProjectJoinDetailsAck {
+    const message = createBaseProjectJoinDetailsAck();
+    message.inviteId = object.inviteId ?? Buffer.alloc(0);
     return message;
   },
 };

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -194,8 +194,8 @@ class Peer {
       listener.reject(new Error('RPC Disconnected before sending'))
     }
     for (const waiters of this.#ackWaiters.values()) {
-      for (const { deffered } of waiters) {
-        deffered.reject(new Error('RPC disconnected before receiving ACK'))
+      for (const { deferred } of waiters) {
+        deferred.reject(new Error('RPC disconnected before receiving ACK'))
       }
     }
     this.#ackWaiters.clear()
@@ -242,13 +242,13 @@ class Peer {
     if (!this.#ackWaiters.has(type)) {
       this.#ackWaiters.set(type, new Set())
     }
-    const deffered = pDefer()
+    const deferred = pDefer()
     this.#ackWaiters.get(type)?.add({
-      deffered,
+      deferred,
       filter,
     })
 
-    await deffered.promise
+    await deferred.promise
   }
 
   /**
@@ -265,7 +265,7 @@ class Peer {
 
     for (const waiter of waiters) {
       if (waiter.filter(ack)) {
-        waiter.deffered.resolve()
+        waiter.deferred.resolve()
         waiters.delete(waiter)
       }
     }

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -509,9 +509,6 @@ export class LocalPeers extends TypedEmitter {
    * @param {DeviceInfo} deviceInfo device info to send
    */
   async sendDeviceInfo(deviceId, deviceInfo) {
-    if (!deviceInfo.features) {
-      deviceInfo.features = []
-    }
     await this.#waitForPendingConnections()
     const peer = await this.#getPeerByDeviceId(deviceId)
     await peer.sendDeviceInfo(deviceInfo)

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -229,7 +229,7 @@ class Peer {
    * @returns {boolean}
    */
   supportsAck() {
-    return this.#features?.includes(DeviceInfo_RPCFeatures.ack) ?? false
+    return this.#features.includes(DeviceInfo_RPCFeatures.ack) ?? false
   }
 
   /**

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -36,7 +36,7 @@ import pTimeout, { TimeoutError } from 'p-timeout'
 /**
  * @typedef {object} AckWaiter
  * @property {AckFilter} filter
- * @property {DeferredPromise<void>} deffered
+ * @property {DeferredPromise<void>} deferred
  */
 
 // Unique identifier for the mapeo rpc protocol

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -275,9 +275,14 @@ export class MapeoManager extends TypedEmitter {
         const deviceInfo = this.getDeviceInfo()
         if (!hasSavedDeviceInfo(deviceInfo)) return
 
+        const deviceInfoToSend = {
+          ...deviceInfo,
+          features: [DeviceInfo_RPCFeatures.ack],
+        }
+
         const peerId = keyToId(openedNoiseStream.remotePublicKey)
 
-        return this.#localPeers.sendDeviceInfo(peerId, deviceInfo)
+        return this.#localPeers.sendDeviceInfo(peerId, deviceInfoToSend)
       })
       .catch((e) => {
         // Ignore error but log

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -26,6 +26,10 @@ import {
 } from './schema/client.js'
 import { ProjectKeys } from './generated/keys.js'
 import {
+  DeviceInfo_RPCFeatures,
+  DeviceInfo_DeviceType,
+} from './generated/rpc.js'
+import {
   deNullify,
   getDeviceId,
   keyToId,
@@ -57,6 +61,7 @@ import { NotFoundError } from './errors.js'
 /** @import { SetNonNullable } from 'type-fest' */
 /** @import { CoreStorage, Namespace } from './types.js' */
 /** @import { DeviceInfoParam } from './schema/client.js' */
+/** @import { DeviceInfo } from './generated/rpc.js' */
 
 /** @typedef {SetNonNullable<ProjectKeys, 'encryptionKeys'>} ValidatedProjectKeys */
 
@@ -720,7 +725,10 @@ export class MapeoManager extends TypedEmitter {
    * @param {T} deviceInfo
    */
   async setDeviceInfo(deviceInfo) {
-    const values = { deviceId: this.#deviceId, deviceInfo }
+    const values = {
+      deviceId: this.#deviceId,
+      deviceInfo,
+    }
     this.#db
       .insert(deviceSettingsTable)
       .values(values)
@@ -747,6 +755,7 @@ export class MapeoManager extends TypedEmitter {
       const deviceInfoToSend = {
         ...deviceInfo,
         deviceType,
+        features: [DeviceInfo_RPCFeatures.ack],
       }
       await Promise.all(
         this.#localPeers.peers
@@ -764,7 +773,7 @@ export class MapeoManager extends TypedEmitter {
    * @returns {(
    *   {
    *     deviceId: string;
-   *     deviceType: DeviceInfoParam['deviceType']
+   *     deviceType: DeviceInfoParam['deviceType'];
    *   } & Partial<DeviceInfoParam>
    * )}
    */
@@ -776,7 +785,7 @@ export class MapeoManager extends TypedEmitter {
       .get()
     return {
       deviceId: this.#deviceId,
-      deviceType: 'device_type_unspecified',
+      deviceType: DeviceInfo_DeviceType.device_type_unspecified,
       ...row?.deviceInfo,
     }
   }

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -186,17 +186,15 @@ export class MemberApi extends TypedEmitter {
         case InviteResponse_Decision.DECISION_UNSPECIFIED:
           return InviteResponse_Decision.REJECT
         case InviteResponse_Decision.ACCEPT:
-          // We should assign the role locally *before* sharing the project details
-          // so that they're part of the project even if they don't receive the
-          // project details message.
-
-          await this.#roles.assignRole(deviceId, roleId)
-
           await this.#rpc.sendProjectJoinDetails(deviceId, {
             inviteId,
             projectKey: this.#projectKey,
             encryptionKeys: this.#encryptionKeys,
           })
+
+          // Only add after we know they got the details
+          // Otherwise the joiner will be stuck unable to join
+          await this.#roles.assignRole(deviceId, roleId)
 
           return inviteResponse.decision
         default:

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -358,7 +358,13 @@ test('member invite rejected', async (t) => {
   })
   const [invite] = await once(joiner.invite, 'invite-received')
 
+  const onInviteUpdated = pEvent(joiner.invite, 'invite-updated', (invite) =>
+    ['rejected', 'error'].includes(invite.state)
+  )
+
   await joiner.invite.reject(invite)
+
+  await onInviteUpdated
 
   assert.equal(
     await responsePromise,

--- a/test/local-peers.js
+++ b/test/local-peers.js
@@ -156,6 +156,7 @@ test('messages to unknown peers', async () => {
     r1.sendDeviceInfo(unknownPeerId, {
       name: 'mapeo',
       deviceType: 'mobile',
+      features: [],
     }),
     UnknownPeerError
   )
@@ -228,7 +229,11 @@ test('Send device info', async () => {
   const r2 = new LocalPeers()
 
   /** @type {import('../src/generated/rpc.js').DeviceInfo} */
-  const expectedDeviceInfo = { name: 'mapeo', deviceType: 'mobile' }
+  const expectedDeviceInfo = {
+    name: 'mapeo',
+    deviceType: 'mobile',
+    features: [],
+  }
 
   r1.on('peers', async (peers) => {
     assert.equal(peers.length, 1)
@@ -252,7 +257,11 @@ test('Send device info immediately', async () => {
   const r2 = new LocalPeers()
 
   /** @type {import('../src/generated/rpc.js').DeviceInfo} */
-  const expectedDeviceInfo = { name: 'mapeo', deviceType: 'mobile' }
+  const expectedDeviceInfo = {
+    name: 'mapeo',
+    deviceType: 'mobile',
+    features: [],
+  }
 
   const kp1 = NoiseSecretStream.keyPair()
   const kp2 = NoiseSecretStream.keyPair()
@@ -276,7 +285,11 @@ test('Reconnect peer and send device info', async () => {
   const r2 = new LocalPeers()
 
   /** @type {import('../src/generated/rpc.js').DeviceInfo} */
-  const expectedDeviceInfo = { name: 'mapeo', deviceType: 'mobile' }
+  const expectedDeviceInfo = {
+    name: 'mapeo',
+    deviceType: 'mobile',
+    features: [],
+  }
 
   const destroy = replicate(r1, r2)
   await once(r1, 'peers')

--- a/test/local-peers.js
+++ b/test/local-peers.js
@@ -329,7 +329,7 @@ test('Device info with ack results in acks sent', async () => {
   const r2 = new LocalPeers()
 
   /** @type {import('../src/generated/rpc.js').DeviceInfo} */
-  const expectedDeviceInfo = {
+  const validDeviceInfo = {
     name: 'mapeo',
     deviceType: 'mobile',
     features: [DeviceInfo_RPCFeatures.ack],
@@ -354,7 +354,7 @@ test('Device info with ack results in acks sent', async () => {
 
   const peers = await pEvent(r1, 'peers')
 
-  r1.sendDeviceInfo(peers[0].deviceId, expectedDeviceInfo)
+  r1.sendDeviceInfo(peers[0].deviceId, validDeviceInfo)
 
   const timeout = 100
 


### PR DESCRIPTION
- Added RPC acknowledge messages alongside the other RPC types
- It only enables if the other side says they have the "Ack" feature.
- This is facilitated by a new "features" flag in DeviceInfo which has a set of features we can add / remove over time. This is how we can facilitate protocol evolution over time
- This has been in service of knowing that invite actions and project details were actually seen on the other side
- We now only add a new member's role to a project after we know they got the project invite details. Fixes #1009
- Found some race conditions in the tests!