### PR TITLE
feat: remove server peer

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -357,18 +357,6 @@ export class MapeoProject extends TypedEmitter {
         deviceInfo: this.#dataTypes.deviceInfo,
         project: this.#dataTypes.projectSettings,
       },
-      isConnectedToServer: (baseUrl) => {
-        return this.#syncApi.isServerConnected(
-          baseUrlToWS(baseUrl, this.#projectPublicId)
-        )
-      },
-      waitForSyncAndDisconnect: async (baseUrl) => {
-        // TODO: Sync with the one device ID?
-        await this.$sync.waitForSync('full')
-        await this.$sync.disconnectServer(
-          baseUrlToWS(baseUrl, this.#projectPublicId)
-        )
-      },
     })
 
     this.#blobStore = new BlobStore({

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -330,7 +330,7 @@ export class MemberApi extends TypedEmitter {
     { dangerouslyAllowInsecureConnections = false } = {}
   ) {
     // Get device ID for URL
-    // Prase through URL to ensure end pathname if missing
+    // Parse through URL to ensure end pathname if missing
     const member = await this.getById(serverDeviceId)
 
     if (!member.selfHostedServerDetails) {

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -379,6 +379,26 @@ export class SyncApi extends TypedEmitter {
   }
 
   /**
+   * @param {string} url
+   * @returns {void}
+   */
+  disconnectServer(url) {
+    if (this.#serverWebsockets.has(url)) {
+      this.#serverWebsockets.get(url)?.close()
+      return true
+    }
+    return false
+  }
+
+  /**
+   * @param {string} url
+   * @returns {boolean}
+   */
+  isServerConnected(url) {
+    return this.#serverWebsockets.has(url)
+  }
+
+  /**
    * Start syncing data cores.
    *
    * If the app is backgrounded and sync has already completed, this will do

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -379,26 +379,6 @@ export class SyncApi extends TypedEmitter {
   }
 
   /**
-   * @param {string} url
-   * @returns {void}
-   */
-  disconnectServer(url) {
-    if (this.#serverWebsockets.has(url)) {
-      this.#serverWebsockets.get(url)?.close()
-      return true
-    }
-    return false
-  }
-
-  /**
-   * @param {string} url
-   * @returns {boolean}
-   */
-  isServerConnected(url) {
-    return this.#serverWebsockets.has(url)
-  }
-
-  /**
    * Start syncing data cores.
    *
    * If the app is backgrounded and sync has already completed, this will do


### PR DESCRIPTION
Closes #999

Some specific stuff I'd like feedback on:
1. Right now this only allows removing while we're replicating. Should I initialize a replication stream if one doesn't exist instead of erroring?
2. Is removing the server by the base URL the easiest for the front end? Should we use the deviceId or some other identifier instead?
3. Are there any events we should be adding to let the front end know the server is removed, or is the role update for the server peer enough?
4. Any other tests I should include here?