### PR TITLE
feat: update @comapeo/schema to 1.5.0 to introduce updated project settings schema

### DIFF
--- a/drizzle/client/0002_brief_demogoblin.sql
+++ b/drizzle/client/0002_brief_demogoblin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE projectSettings ADD `projectDescription` text;--> statement-breakpoint
+ALTER TABLE projectSettings ADD `projectColor` text;

--- a/drizzle/client/meta/0002_snapshot.json
+++ b/drizzle/client/meta/0002_snapshot.json
@@ -1,0 +1,220 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "facbbc92-fe5b-4ce0-9bcd-189143af55f9",
+  "prevId": "a80440f2-1097-40a6-ab81-3295f0a8c5c1",
+  "tables": {
+    "deviceSettings": {
+      "name": "deviceSettings",
+      "columns": {
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isArchiveDevice": {
+          "name": "isArchiveDevice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deviceSettings_deviceId_unique": {
+          "name": "deviceSettings_deviceId_unique",
+          "columns": [
+            "deviceId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings_backlink": {
+      "name": "projectSettings_backlink",
+      "columns": {
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectKeys": {
+      "name": "projectKeys",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectPublicId": {
+          "name": "projectPublicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInviteId": {
+          "name": "projectInviteId",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keysCipher": {
+          "name": "keysCipher",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInfo": {
+          "name": "projectInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings": {
+      "name": "projectSettings",
+      "columns": {
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalVersionId": {
+          "name": "originalVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schemaName": {
+          "name": "schemaName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectDescription": {
+          "name": "projectDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectColor": {
+          "name": "projectColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultPresets": {
+          "name": "defaultPresets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configMetadata": {
+          "name": "configMetadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forks": {
+          "name": "forks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1729605656745,
       "tag": "0001_chubby_cargill",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1744822575870,
+      "tag": "0002_brief_demogoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "1.4.1",
+        "@comapeo/schema": "1.5.0",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.4.1.tgz",
-      "integrity": "sha512-Uh8kBluSWS8C9lI2tuM7emR1zPnCiMFKpY/0chUe3Peb92YSWzZ6iApHd5qRwljruamr99OBX35HVe8EnaPi+g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
+      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
         "compact-encoding": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "1.4.1",
+    "@comapeo/schema": "1.5.0",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -9,6 +9,9 @@ message Invite {
   optional string roleName = 4;
   optional string roleDescription = 5;
   string invitorName = 6;
+  // TODO: Should this be required?
+  optional string projectColor = 7;
+  optional string projectDescription = 8;
 }
 
 message InviteCancel {

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -9,7 +9,6 @@ message Invite {
   optional string roleName = 4;
   optional string roleDescription = 5;
   string invitorName = 6;
-  // TODO: Should this be required?
   optional string projectColor = 7;
   optional string projectDescription = 8;
 }

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -7,7 +7,6 @@ export interface Invite {
     roleName?: string | undefined;
     roleDescription?: string | undefined;
     invitorName: string;
-    /** TODO: Should this be required? */
     projectColor?: string | undefined;
     projectDescription?: string | undefined;
 }

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -7,6 +7,9 @@ export interface Invite {
     roleName?: string | undefined;
     roleDescription?: string | undefined;
     invitorName: string;
+    /** TODO: Should this be required? */
+    projectColor?: string | undefined;
+    projectDescription?: string | undefined;
 }
 export interface InviteCancel {
     inviteId: Buffer;

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -139,6 +139,12 @@ export var Invite = {
         if (message.invitorName !== "") {
             writer.uint32(50).string(message.invitorName);
         }
+        if (message.projectColor !== undefined) {
+            writer.uint32(58).string(message.projectColor);
+        }
+        if (message.projectDescription !== undefined) {
+            writer.uint32(66).string(message.projectDescription);
+        }
         return writer;
     },
     decode: function (input, length) {
@@ -184,6 +190,18 @@ export var Invite = {
                     }
                     message.invitorName = reader.string();
                     continue;
+                case 7:
+                    if (tag !== 58) {
+                        break;
+                    }
+                    message.projectColor = reader.string();
+                    continue;
+                case 8:
+                    if (tag !== 66) {
+                        break;
+                    }
+                    message.projectDescription = reader.string();
+                    continue;
             }
             if ((tag & 7) === 4 || tag === 0) {
                 break;
@@ -196,7 +214,7 @@ export var Invite = {
         return Invite.fromPartial(base !== null && base !== void 0 ? base : {});
     },
     fromPartial: function (object) {
-        var _a, _b, _c, _d, _e, _f;
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         var message = createBaseInvite();
         message.inviteId = (_a = object.inviteId) !== null && _a !== void 0 ? _a : Buffer.alloc(0);
         message.projectInviteId = (_b = object.projectInviteId) !== null && _b !== void 0 ? _b : Buffer.alloc(0);
@@ -204,6 +222,8 @@ export var Invite = {
         message.roleName = (_d = object.roleName) !== null && _d !== void 0 ? _d : undefined;
         message.roleDescription = (_e = object.roleDescription) !== null && _e !== void 0 ? _e : undefined;
         message.invitorName = (_f = object.invitorName) !== null && _f !== void 0 ? _f : "";
+        message.projectColor = (_g = object.projectColor) !== null && _g !== void 0 ? _g : undefined;
+        message.projectDescription = (_h = object.projectDescription) !== null && _h !== void 0 ? _h : undefined;
         return message;
     },
 };

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -9,6 +9,9 @@ export interface Invite {
   roleName?: string | undefined;
   roleDescription?: string | undefined;
   invitorName: string;
+  /** TODO: Should this be required? */
+  projectColor?: string | undefined;
+  projectDescription?: string | undefined;
 }
 
 export interface InviteCancel {
@@ -201,6 +204,12 @@ export const Invite = {
     if (message.invitorName !== "") {
       writer.uint32(50).string(message.invitorName);
     }
+    if (message.projectColor !== undefined) {
+      writer.uint32(58).string(message.projectColor);
+    }
+    if (message.projectDescription !== undefined) {
+      writer.uint32(66).string(message.projectDescription);
+    }
     return writer;
   },
 
@@ -253,6 +262,20 @@ export const Invite = {
 
           message.invitorName = reader.string();
           continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.projectColor = reader.string();
+          continue;
+        case 8:
+          if (tag !== 66) {
+            break;
+          }
+
+          message.projectDescription = reader.string();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -273,6 +296,8 @@ export const Invite = {
     message.roleName = object.roleName ?? undefined;
     message.roleDescription = object.roleDescription ?? undefined;
     message.invitorName = object.invitorName ?? "";
+    message.projectColor = object.projectColor ?? undefined;
+    message.projectDescription = object.projectDescription ?? undefined;
     return message;
   },
 };

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -9,7 +9,6 @@ export interface Invite {
   roleName?: string | undefined;
   roleDescription?: string | undefined;
   invitorName: string;
-  /** TODO: Should this be required? */
   projectColor?: string | undefined;
   projectDescription?: string | undefined;
 }

--- a/src/invite/invite-api.js
+++ b/src/invite/invite-api.js
@@ -12,6 +12,7 @@ import {
   InviteSendError,
 } from '../errors.js'
 
+/** @import { ProjectToAddDetails } from '../mapeo-manager.js' */
 /** @import { MapBuffers } from '../types.js' */
 /**
  * @import {
@@ -45,7 +46,7 @@ import {
  */
 
 /**
- * @typedef {(projectDetails: Pick<ProjectJoinDetails, 'projectKey' | 'encryptionKeys'> & { projectName: string }) => Promise<string>} AddProjectQuery
+ * @typedef {(projectDetails: ProjectToAddDetails) => Promise<string>} AddProjectQuery
  */
 
 /**
@@ -119,7 +120,13 @@ export class InviteApi extends TypedEmitter {
    * @param {InviteRpcMessage} inviteRpcMessage
    */
   #handleNewInvite(peerId, inviteRpcMessage) {
-    const { inviteId, projectInviteId, projectName } = inviteRpcMessage
+    const {
+      inviteId,
+      projectInviteId,
+      projectName,
+      projectColor,
+      projectDescription,
+    } = inviteRpcMessage
     const invite = { ...inviteRpcMessage, receivedAt: Date.now() }
 
     this.#l.log('Received invite %h from %S', inviteId, peerId)
@@ -149,7 +156,12 @@ export class InviteApi extends TypedEmitter {
             return this.rpc.sendInviteResponse(peerId, { decision, inviteId })
           }),
           addProject: fromPromise(async ({ input: projectDetails }) => {
-            return this.#addProject({ ...projectDetails, projectName })
+            return this.#addProject({
+              ...projectDetails,
+              projectName,
+              projectColor,
+              projectDescription,
+            })
           }),
         },
         guards: {

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -155,8 +155,6 @@ export class MemberApi extends TypedEmitter {
       const projectInviteId = projectKeyToProjectInviteId(this.#projectKey)
       const project = await this.#dataTypes.project.getByDocId(projectId)
       const projectName = project.name
-
-      // TODO: Require projectColor to be set as well?
       assert(projectName, 'Project must have a name to invite people')
 
       const projectColor = project.projectColor

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -155,7 +155,12 @@ export class MemberApi extends TypedEmitter {
       const projectInviteId = projectKeyToProjectInviteId(this.#projectKey)
       const project = await this.#dataTypes.project.getByDocId(projectId)
       const projectName = project.name
+
+      // TODO: Require projectColor to be set as well?
       assert(projectName, 'Project must have a name to invite people')
+
+      const projectColor = project.projectColor
+      const projectDescription = project.projectDescription
 
       abortSignal.throwIfAborted()
 
@@ -163,6 +168,8 @@ export class MemberApi extends TypedEmitter {
         inviteId,
         projectInviteId,
         projectName,
+        projectColor,
+        projectDescription,
         roleName,
         roleDescription,
         invitorName,

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -7,9 +7,10 @@ import { jsonSchemaToDrizzleColumns as toColumns } from './schema-to-drizzle.js'
 import { backlinkTable, customJson } from './utils.js'
 
 /**
+ * @import { ProjectSettings } from '@comapeo/schema'
+ *
  * @internal
- * @typedef {object} ProjectInfo
- * @prop {string} [name]
+ * @typedef {Pick<ProjectSettings, 'name' | 'projectColor' | 'projectDescription'>} ProjectInfo
  */
 
 const projectInfoColumn =

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -65,6 +65,8 @@ test('Managing created projects', async (t) => {
       settings1,
       {
         name: undefined,
+        projectColor: undefined,
+        projectDescription: undefined,
         defaultPresets: undefined,
         configMetadata: undefined,
       },
@@ -74,6 +76,8 @@ test('Managing created projects', async (t) => {
       settings2,
       {
         name: 'project 2',
+        projectColor: undefined,
+        projectDescription: undefined,
         defaultPresets: undefined,
         configMetadata: undefined,
       },
@@ -84,15 +88,31 @@ test('Managing created projects', async (t) => {
   await t.test('after updating project settings', async () => {
     await project1.$setProjectSettings({
       name: 'project 1',
+      projectColor: '#123456',
     })
     await project2.$setProjectSettings({
       name: 'project 2 updated',
+      projectDescription: 'project 2 description',
     })
 
     const settings1 = await project1.$getProjectSettings()
     const settings2 = await project2.$getProjectSettings()
 
-    assert.equal(settings1.name, 'project 1')
+    assert.deepEqual(settings1, {
+      name: 'project 1',
+      projectColor: '#123456',
+      projectDescription: undefined,
+      defaultPresets: undefined,
+      configMetadata: undefined,
+    })
+
+    assert.deepEqual(settings2, {
+      name: 'project 2 updated',
+      projectColor: undefined,
+      projectDescription: 'project 2 description',
+      defaultPresets: undefined,
+      configMetadata: undefined,
+    })
 
     assert.equal(settings2.name, 'project 2 updated')
 
@@ -109,14 +129,38 @@ test('Managing created projects', async (t) => {
     )
 
     assert(project1FromListed)
-    assert.equal(project1FromListed?.name, 'project 1')
-    assert(project1FromListed?.createdAt)
-    assert(project1FromListed?.updatedAt)
+
+    const {
+      createdAt: project1CreatedAt,
+      updatedAt: project1UpdatedAt,
+      ...project1OtherInfo
+    } = project1FromListed
+
+    assert(project1CreatedAt)
+    assert(project1UpdatedAt)
+    assert.deepEqual(project1OtherInfo, {
+      projectId: project1Id,
+      name: 'project 1',
+      projectColor: '#123456',
+      projectDescription: undefined,
+    })
 
     assert(project2FromListed)
-    assert.equal(project2FromListed?.name, 'project 2 updated')
-    assert(project2FromListed?.createdAt)
-    assert(project2FromListed?.updatedAt)
+
+    const {
+      createdAt: project2CreatedAt,
+      updatedAt: project2UpdatedAt,
+      ...project2OtherInfo
+    } = project2FromListed
+
+    assert(project2CreatedAt)
+    assert(project2UpdatedAt)
+    assert.deepEqual(project2OtherInfo, {
+      projectId: project2Id,
+      name: 'project 2 updated',
+      projectColor: undefined,
+      projectDescription: 'project 2 description',
+    })
   })
 })
 
@@ -304,11 +348,15 @@ test('Managing added projects', async (t) => {
       assert.deepEqual(settings1, {
         name: 'project 1',
         defaultPresets: undefined,
+        projectColor: undefined,
+        projectDescription: undefined,
       })
 
       assert.deepEqual(settings2, {
         name: 'project 2',
         defaultPresets: undefined,
+        projectColor: undefined,
+        projectDescription: undefined,
       })
     }
   )

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -17,7 +17,11 @@ test('member invite accepted & invite states', async (t) => {
   t.after(disconnectPeers)
   await waitForPeers([creator, joiner])
 
-  const createdProjectId = await creator.createProject({ name: 'Mapeo' })
+  const createdProjectId = await creator.createProject({
+    name: 'Mapeo',
+    projectColor: '#123456',
+    projectDescription: 'fun project',
+  })
   const creatorProject = await creator.getProject(createdProjectId)
 
   await assert.rejects(
@@ -41,6 +45,16 @@ test('member invite accepted & invite states', async (t) => {
     'inviteId has at least 256 bits of entropy'
   )
   assert.equal(invite.projectName, 'Mapeo', 'project name of invite matches')
+  assert.equal(
+    invite.projectColor,
+    '#123456',
+    'project color of invite matches'
+  )
+  assert.equal(
+    invite.projectDescription,
+    'fun project',
+    'project description of invite matches'
+  )
 
   const acceptPromise = joiner.invite.accept(invite)
 

--- a/test-e2e/members.js
+++ b/test-e2e/members.js
@@ -116,6 +116,27 @@ test('getting yourself after adding project (but not yet synced)', async (t) => 
   )
 })
 
+test('cannot invite when project is missing critical details', async (t) => {
+  const managers = await createManagers(2, t)
+  const [invitor, invitee] = managers
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
+
+  // Note: no name for created project
+  const projectId = await invitor.createProject()
+  const project = await invitor.getProject(projectId)
+
+  await assert.rejects(
+    () => {
+      return project.$member.invite(invitee.deviceId, {
+        roleId: MEMBER_ROLE_ID,
+      })
+    },
+    /Error: Project must have a name to invite people/,
+    'Cannot invite when project is missing name'
+  )
+})
+
 test('getting invited member after invite rejected', async (t) => {
   const managers = await createManagers(2, t)
   const [invitor, invitee] = managers

--- a/test-e2e/project-settings.js
+++ b/test-e2e/project-settings.js
@@ -46,6 +46,8 @@ test('Project settings create, read, and update operations', async () => {
 
   const expectedSettings = {
     name: 'updated',
+    projectColor: '#123456',
+    projectDescription: 'cool project',
   }
 
   const updatedSettings = await project.$setProjectSettings(expectedSettings)

--- a/test/invite-api.js
+++ b/test/invite-api.js
@@ -71,6 +71,7 @@ test('invite-received event has expected payload', async () => {
   const partialInvite = {
     ...bareInvite,
     inviteId: randomBytes(32),
+    projectColor: '#123456',
     roleDescription: 'Cool Role',
   }
   rpc.emit('invite', invitorPeerId, partialInvite)
@@ -80,6 +81,7 @@ test('invite-received event has expected payload', async () => {
     inviteId: randomBytes(32),
     roleName: 'Superfan',
     roleDescription: 'This Cool Role',
+    projectDescription: 'cool project',
   }
   rpc.emit('invite', invitorPeerId, fullInvite)
 
@@ -99,6 +101,7 @@ test('invite-received event has expected payload', async () => {
       projectName,
       roleDescription: 'Cool Role',
       invitorName: 'Your Friend',
+      projectColor: '#123456',
       state: 'pending',
     },
     {
@@ -109,6 +112,7 @@ test('invite-received event has expected payload', async () => {
       roleName: 'Superfan',
       roleDescription: 'This Cool Role',
       invitorName: 'Your Friend',
+      projectDescription: 'cool project',
       state: 'pending',
     },
   ]


### PR DESCRIPTION
Closes #1014 

Surface area feels kind of large at the moment - I'm open to breaking it up if it makes sense to (with some guidance).

Summary of changes:

- Adds a database migration for the client database schema to add support for the `projectColor` and `projectDescription` fields as part of the `projectInfo` column.

- Updates the invite RPC message to add `projectColor` and `projectDescription` fields (both optional).
    
    - ~**Question**: should the `projectColor` be a required field? `projectName` is a required field but not sure if the color should follow suite. Based on UX needs, maybe it makes sense to, but can also imagine it being okay to omit and letting the app handle using a fallback.~ EDIT: at the RPC level, it has to be optional for compat reasons. at the app api level, we decided to leave it as optional and let the frontend handle it.
    
- Updates the `MapeoManager` to support creating a project with a color and description specified (both optional).

- Updates the `MapeoManager` to support the color and description fields when adding a project (mostly relevant for when accepting an invite).

- Updates the `MemberApi` to include the project color and description when sending an invite (both optional).

- Updates affected tests. Didn't put too much emphasis on trying to introduce new tests, but open to doing so with some guidance on what's considered worthy of adding.
