### PR TITLE
Fix/ensure invite config sync

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -31,7 +31,7 @@ export class InviteAbortedError extends Error {
 
 export class ProjectDetailsSendFail extends Error {
   /** @param {string} [message] */
-  constructor(message = 'Project Details Failed to send') {
+  constructor(message = 'Project details failed to send') {
     super(message)
     this.name = 'ProjectDetailsSendFail'
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -29,35 +29,35 @@ export class InviteAbortedError extends Error {
   }
 }
 
-export class ProjectDetailsSendFail extends Error {
+export class ProjectDetailsSendFailError extends Error {
   /** @param {string} [message] */
   constructor(message = 'Project details failed to send') {
     super(message)
-    this.name = 'ProjectDetailsSendFail'
+    this.name = 'ProjectDetailsSendFailError'
   }
 }
 
-export class InviteInitialSyncFail extends Error {
+export class InviteInitialSyncFailError extends Error {
   /** @param {string} [message] */
   constructor(message = 'Failed to sync config for invite') {
     super(message)
-    this.name = 'InviteInitialSyncFail'
+    this.name = 'InviteInitialSyncFailError'
   }
 }
 
-export class RPCDisconnectBeforeSending extends Error {
+export class RPCDisconnectBeforeSendingError extends Error {
   /** @param {string} [message] */
   constructor(message = 'RPC disconnected before sending') {
     super(message)
-    this.name = 'RPCDisconnectBeforeSending'
+    this.name = 'RPCDisconnectBeforeSendingError'
   }
 }
 
-export class RPCDisconnectBeforeAck extends Error {
+export class RPCDisconnectBeforeAckError extends Error {
   /** @param {string} [message] */
   constructor(message = 'RPC disconnected before receiving acknowledgement') {
     super(message)
-    this.name = 'RPCDisconnectBeforeAck'
+    this.name = 'RPCDisconnectBeforeAckError'
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -55,7 +55,7 @@ export class RPCDisconnectBeforeSending extends Error {
 
 export class RPCDisconnectBeforeAck extends Error {
   /** @param {string} [message] */
-  constructor(message = 'RPC disconnected before recieving acknowledgement') {
+  constructor(message = 'RPC disconnected before receiving acknowledgement') {
     super(message)
     this.name = 'RPCDisconnectBeforeAck'
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -29,6 +29,38 @@ export class InviteAbortedError extends Error {
   }
 }
 
+export class ProjectDetailsSendFail extends Error {
+  /** @param {string} [message] */
+  constructor(message = 'Project Details Failed to send') {
+    super(message)
+    this.name = 'ProjectDetailsSendFail'
+  }
+}
+
+export class InviteInitialSyncFail extends Error {
+  /** @param {string} [message] */
+  constructor(message = 'Failed to sync config for invite') {
+    super(message)
+    this.name = 'InviteInitialSyncFail'
+  }
+}
+
+export class RPCDisconnectBeforeSending extends Error {
+  /** @param {string} [message] */
+  constructor(message = 'RPC disconnected before sending') {
+    super(message)
+    this.name = 'RPCDisconnectBeforeSending'
+  }
+}
+
+export class RPCDisconnectBeforeAck extends Error {
+  /** @param {string} [message] */
+  constructor(message = 'RPC disconnected before recieving acknowledgement') {
+    super(message)
+    this.name = 'RPCDisconnectBeforeAck'
+  }
+}
+
 export class TimeoutError extends Error {
   /** @param {string} [message] */
   constructor(message = 'TimeoutError') {

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -19,6 +19,7 @@ import {
 import pDefer from 'p-defer'
 import { Logger } from './logger.js'
 import pTimeout, { TimeoutError } from 'p-timeout'
+import { RPCDisconnectBeforeAck, RPCDisconnectBeforeSending } from './errors.js'
 /** @import NoiseStream from '@hyperswarm/secret-stream' */
 /** @import { OpenedNoiseStream } from './lib/noise-secret-stream-helpers.js' */
 /** @import {DeferredPromise} from 'p-defer' */
@@ -191,11 +192,11 @@ class Peer {
     // This promise should have already resolved, but if the peer never connected then we reject here
     this.#connected.reject(new PeerFailedConnectionError())
     for (const listener of this.#drainedListeners) {
-      listener.reject(new Error('RPC Disconnected before sending'))
+      listener.reject(new RPCDisconnectBeforeSending())
     }
     for (const waiters of this.#ackWaiters.values()) {
       for (const { deferred } of waiters) {
-        deferred.reject(new Error('RPC disconnected before receiving ACK'))
+        deferred.reject(new RPCDisconnectBeforeAck())
       }
     }
     this.#ackWaiters.clear()

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -19,7 +19,10 @@ import {
 import pDefer from 'p-defer'
 import { Logger } from './logger.js'
 import pTimeout, { TimeoutError } from 'p-timeout'
-import { RPCDisconnectBeforeAck, RPCDisconnectBeforeSending } from './errors.js'
+import {
+  RPCDisconnectBeforeAckError,
+  RPCDisconnectBeforeSendingError,
+} from './errors.js'
 /** @import NoiseStream from '@hyperswarm/secret-stream' */
 /** @import { OpenedNoiseStream } from './lib/noise-secret-stream-helpers.js' */
 /** @import {DeferredPromise} from 'p-defer' */
@@ -192,11 +195,11 @@ class Peer {
     // This promise should have already resolved, but if the peer never connected then we reject here
     this.#connected.reject(new PeerFailedConnectionError())
     for (const listener of this.#drainedListeners) {
-      listener.reject(new RPCDisconnectBeforeSending())
+      listener.reject(new RPCDisconnectBeforeSendingError())
     }
     for (const waiters of this.#ackWaiters.values()) {
       for (const { deferred } of waiters) {
-        deferred.reject(new RPCDisconnectBeforeAck())
+        deferred.reject(new RPCDisconnectBeforeAckError())
       }
     }
     this.#ackWaiters.clear()

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -224,7 +224,7 @@ export class MemberApi extends TypedEmitter {
           } catch {
             // Mark them as "left" so we can retry the flow
             await this.#roles.assignRole(deviceId, LEFT_ROLE_ID)
-            throw InviteInitialSyncFail()
+            throw new InviteInitialSyncFail()
           }
 
           return inviteResponse.decision

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -25,6 +25,7 @@ import {
 import { wsCoreReplicator } from './lib/ws-core-replicator.js'
 import {
   BLOCKED_ROLE_ID,
+  LEFT_ROLE_ID,
   MEMBER_ROLE_ID,
   ROLES,
   isRoleIdForNewInvite,
@@ -221,6 +222,8 @@ export class MemberApi extends TypedEmitter {
           try {
             await this.#waitForInitialSyncWithPeer(deviceId, abortSignal)
           } catch {
+            // Mark them as "left" so we can retry the flow
+            await this.#roles.assignRole(deviceId, LEFT_ROLE_ID)
             throw InviteInitialSyncFail()
           }
 

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -219,7 +219,7 @@ export class MemberApi extends TypedEmitter {
             })
           } catch {
             try {
-              // Mark them as "left" so we can retry the flow
+              // Mark them as "failed" so we can retry the flow
               await this.#roles.assignRole(deviceId, FAILED_ROLE_ID)
             } catch (e) {
               console.error(e)

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -25,8 +25,6 @@ import {
 import { wsCoreReplicator } from './lib/ws-core-replicator.js'
 import {
   BLOCKED_ROLE_ID,
-  COORDINATOR_ROLE_ID,
-  CREATOR_ROLE_ID,
   FAILED_ROLE_ID,
   MEMBER_ROLE_ID,
   ROLES,
@@ -534,19 +532,6 @@ export class MemberApi extends TypedEmitter {
     }
 
     return result
-  }
-
-  /**
-   * Get active members, excludes no role, blocked, and removed
-   * @returns {Promise<Array<MemberInfo>>}
-   */
-  async getActive() {
-    const members = await this.getMany()
-    return members.filter(({ role }) =>
-      [MEMBER_ROLE_ID, COORDINATOR_ROLE_ID, CREATOR_ROLE_ID].includes(
-        role.roleId
-      )
-    )
   }
 
   /**

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -19,13 +19,15 @@ import { isHostnameIpAddress } from './lib/is-hostname-ip-address.js'
 import { ErrorWithCode, getErrorMessage } from './lib/error.js'
 import {
   InviteAbortedError,
-  InviteInitialSyncFail,
-  ProjectDetailsSendFail,
+  InviteInitialSyncFailError,
+  ProjectDetailsSendFailError,
 } from './errors.js'
 import { wsCoreReplicator } from './lib/ws-core-replicator.js'
 import {
   BLOCKED_ROLE_ID,
-  LEFT_ROLE_ID,
+  COORDINATOR_ROLE_ID,
+  CREATOR_ROLE_ID,
+  FAILED_ROLE_ID,
   MEMBER_ROLE_ID,
   ROLES,
   isRoleIdForNewInvite,
@@ -205,6 +207,10 @@ export class MemberApi extends TypedEmitter {
         case InviteResponse_Decision.DECISION_UNSPECIFIED:
           return InviteResponse_Decision.REJECT
         case InviteResponse_Decision.ACCEPT:
+          // Technically we can assign after sending project details
+          // This lets us test role removal
+          await this.#roles.assignRole(deviceId, roleId)
+
           try {
             await this.#rpc.sendProjectJoinDetails(deviceId, {
               inviteId,
@@ -212,19 +218,21 @@ export class MemberApi extends TypedEmitter {
               encryptionKeys: this.#encryptionKeys,
             })
           } catch {
-            throw new ProjectDetailsSendFail()
+            try {
+              // Mark them as "left" so we can retry the flow
+              await this.#roles.assignRole(deviceId, FAILED_ROLE_ID)
+            } catch (e) {
+              console.error(e)
+            }
+            throw new ProjectDetailsSendFailError()
           }
-
-          // Only add after we know they got the details
-          // Otherwise the joiner will be stuck unable to join
-          await this.#roles.assignRole(deviceId, roleId)
 
           try {
             await this.#waitForInitialSyncWithPeer(deviceId, abortSignal)
           } catch {
             // Mark them as "left" so we can retry the flow
-            await this.#roles.assignRole(deviceId, LEFT_ROLE_ID)
-            throw new InviteInitialSyncFail()
+            await this.#roles.assignRole(deviceId, FAILED_ROLE_ID)
+            throw new InviteInitialSyncFailError()
           }
 
           return inviteResponse.decision
@@ -526,6 +534,19 @@ export class MemberApi extends TypedEmitter {
     }
 
     return result
+  }
+
+  /**
+   * Get active members, excludes no role, blocked, and removed
+   * @returns {Promise<Array<MemberInfo>>}
+   */
+  async getActive() {
+    const members = await this.getMany()
+    return members.filter(({ role }) =>
+      [MEMBER_ROLE_ID, COORDINATOR_ROLE_ID, CREATOR_ROLE_ID].includes(
+        role.roleId
+      )
+    )
   }
 
   /**

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -230,7 +230,7 @@ export class MemberApi extends TypedEmitter {
           try {
             await this.#waitForInitialSyncWithPeer(deviceId, abortSignal)
           } catch {
-            // Mark them as "left" so we can retry the flow
+            // Mark them as "failed" so we can retry the flow
             await this.#roles.assignRole(deviceId, FAILED_ROLE_ID)
             throw new InviteInitialSyncFailError()
           }

--- a/src/roles.js
+++ b/src/roles.js
@@ -135,7 +135,7 @@ const BLOCKED_ROLE = {
  */
 const FAILED_ROLE = {
   roleId: FAILED_ROLE_ID,
-  name: 'Blocked',
+  name: 'Failed',
   docs: mapObject(currentSchemaVersions, (key) => {
     return [
       key,

--- a/src/roles.js
+++ b/src/roles.js
@@ -12,6 +12,7 @@ export const COORDINATOR_ROLE_ID = 'f7c150f5a3a9a855'
 export const MEMBER_ROLE_ID = '012fd2d431c0bf60'
 export const BLOCKED_ROLE_ID = '9e6d29263cba36c9'
 export const LEFT_ROLE_ID = '8ced989b1904606b'
+export const FAILED_ROLE_ID = 'a24eaca65ab5d5d0'
 export const NO_ROLE_ID = '08e4251e36f6e7ed'
 
 /**
@@ -27,6 +28,7 @@ const ROLE_IDS = new Set(
     MEMBER_ROLE_ID,
     BLOCKED_ROLE_ID,
     LEFT_ROLE_ID,
+    FAILED_ROLE_ID,
     NO_ROLE_ID,
   ])
 )
@@ -51,6 +53,7 @@ const ROLE_IDS_ASSIGNABLE_TO_ANYONE = new Set(
     MEMBER_ROLE_ID,
     BLOCKED_ROLE_ID,
     LEFT_ROLE_ID,
+    FAILED_ROLE_ID,
   ])
 )
 const isRoleIdAssignableToAnyone = setHas(ROLE_IDS_ASSIGNABLE_TO_ANYONE)
@@ -104,6 +107,34 @@ export const CREATOR_ROLE = {
  */
 const BLOCKED_ROLE = {
   roleId: BLOCKED_ROLE_ID,
+  name: 'Blocked',
+  docs: mapObject(currentSchemaVersions, (key) => {
+    return [
+      key,
+      {
+        readOwn: false,
+        writeOwn: false,
+        readOthers: false,
+        writeOthers: false,
+      },
+    ]
+  }),
+  roleAssignment: [],
+  sync: {
+    auth: 'blocked',
+    config: 'blocked',
+    data: 'blocked',
+    blobIndex: 'blocked',
+    blob: 'blocked',
+  },
+}
+
+/**
+ * This role is used for devices that failed to sync after accepting an invite and being added
+ * @type {Role<typeof FAILED_ROLE_ID>}
+ */
+const FAILED_ROLE = {
+  roleId: FAILED_ROLE_ID,
   name: 'Blocked',
   docs: mapObject(currentSchemaVersions, (key) => {
     return [
@@ -219,6 +250,7 @@ export const ROLES = {
     },
   },
   [NO_ROLE_ID]: NO_ROLE,
+  [FAILED_ROLE_ID]: FAILED_ROLE,
 }
 
 /**
@@ -379,6 +411,11 @@ export class Roles extends TypedEmitter {
     if (roleId === LEFT_ROLE_ID) {
       if (deviceId !== this.#ownDeviceId) {
         throw new Error('Cannot assign LEFT role to another device')
+      }
+    } else if (roleId === FAILED_ROLE_ID) {
+      const ownRole = await this.getRole(this.#ownDeviceId)
+      if (!ownRole.roleAssignment.includes(COORDINATOR_ROLE_ID)) {
+        throw new Error('Lacks permission to assign role ' + roleId)
       }
     } else {
       const ownRole = await this.getRole(this.#ownDeviceId)

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -667,6 +667,10 @@ test('disconnect before sending project join details', async (t) => {
   // Run down the timeout waiting for project details
   clock.runAll()
   await Promise.all([assertInviteRejectsPromise, assertAcceptRejectsPromise])
+
+  const members = await creatorProject.$member.getMany()
+
+  assert.equal(members.length, 1, 'Member did not get added after fail')
 })
 
 test('Attempting to accept unknown inviteId throws', async (t) => {

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -638,7 +638,7 @@ test('disconnect before invite accept', async (t) => {
 // TODO: It's not possible in e2e tests to disconnect peers at the right moment.
 // This test is flaky, and sometimes the project details are sent before the
 // peers disconnect, so can't expect specific errors.
-test.only('disconnect before sending project join details', async (t) => {
+test('disconnect before sending project join details', async (t) => {
   const clock = FakeTimers.install({ shouldAdvanceTime: true })
   t.after(() => clock.uninstall())
   const [creator, joiner] = await createManagers(2, t)

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -9,7 +9,7 @@ import FakeTimers from '@sinonjs/fake-timers'
 import { randomBytes } from 'node:crypto'
 import { noop } from '../src/utils.js'
 
-const { COORDINATOR_ROLE_ID, MEMBER_ROLE_ID } = roles
+const { COORDINATOR_ROLE_ID, CREATOR_ROLE_ID, MEMBER_ROLE_ID } = roles
 
 test('member invite accepted & invite states', async (t) => {
   const [creator, joiner] = await createManagers(2, t)
@@ -668,7 +668,10 @@ test('disconnect before sending project join details', async (t) => {
   clock.runAll()
   await Promise.all([assertInviteRejectsPromise, assertAcceptRejectsPromise])
 
-  const members = await creatorProject.$member.getActive()
+  const members = (await creatorProject.$member.getMany()).filter(({ role }) =>
+    // @ts-ignore - TS2345
+    [MEMBER_ROLE_ID, COORDINATOR_ROLE_ID, CREATOR_ROLE_ID].includes(role.roleId)
+  )
 
   assert.equal(members.length, 1, 'Member did not get added after fail')
 
@@ -686,7 +689,10 @@ test('disconnect before sending project join details', async (t) => {
 
   await invitePromise2
 
-  const members2 = await creatorProject.$member.getActive()
+  const members2 = (await creatorProject.$member.getMany()).filter(({ role }) =>
+    // @ts-ignore - TS2345
+    [MEMBER_ROLE_ID, COORDINATOR_ROLE_ID, CREATOR_ROLE_ID].includes(role.roleId)
+  )
 
   assert.equal(members2.length, 2, 'Member got added after retry')
 })

--- a/test-e2e/manager-invite.js
+++ b/test-e2e/manager-invite.js
@@ -637,48 +637,37 @@ test('disconnect before invite accept', async (t) => {
 
 // TODO: It's not possible in e2e tests to disconnect peers at the right moment.
 // This test is flaky, and sometimes the project details are sent before the
-// peers disconnect, so skipping this test for now.
-test(
-  'disconnect before sending project join details',
-  { skip: true },
-  async (t) => {
-    const clock = FakeTimers.install({ shouldAdvanceTime: true })
-    t.after(() => clock.uninstall())
-    const [creator, joiner] = await createManagers(2, t)
-    const disconnectPeers = connectPeers([creator, joiner])
-    t.after(() => disconnectPeers())
-    await waitForPeers([creator, joiner])
+// peers disconnect, so can't expect specific errors.
+test('disconnect before sending project join details', async (t) => {
+  const clock = FakeTimers.install({ shouldAdvanceTime: true })
+  t.after(() => clock.uninstall())
+  const [creator, joiner] = await createManagers(2, t)
+  const disconnectPeers = connectPeers([creator, joiner])
+  t.after(() => disconnectPeers())
+  await waitForPeers([creator, joiner])
 
-    const createdProjectId = await creator.createProject({ name: 'Mapeo' })
-    const creatorProject = await creator.getProject(createdProjectId)
+  const createdProjectId = await creator.createProject({ name: 'Mapeo' })
+  const creatorProject = await creator.getProject(createdProjectId)
 
-    const inviteReceivedPromise = pEvent(joiner.invite, 'invite-received')
-    const invitePromise = creatorProject.$member.invite(joiner.deviceId, {
-      roleId: MEMBER_ROLE_ID,
-    })
-    const assertInviteRejectsPromise = assert.rejects(
-      invitePromise,
-      {
-        name: 'PeerDisconnectedError',
-        message: 'Peer disconnected before sending project join details',
-      },
-      'invite promise rejects when peer disconnects'
-    )
-    const invite = await inviteReceivedPromise
-    const assertAcceptRejectsPromise = assert.rejects(
-      () => joiner.invite.accept(invite),
-      {
-        name: 'TimeoutError',
-        message: 'Timed out waiting for project details',
-      },
-      'accepting invite times out when project details are not received'
-    )
-    await disconnectPeers()
-    // Run down the timeout waiting for project details
-    clock.runAll()
-    await Promise.all([assertInviteRejectsPromise, assertAcceptRejectsPromise])
-  }
-)
+  const inviteReceivedPromise = pEvent(joiner.invite, 'invite-received')
+  const invitePromise = creatorProject.$member.invite(joiner.deviceId, {
+    roleId: MEMBER_ROLE_ID,
+  })
+  // Specific error can be different due to race conditions
+  const assertInviteRejectsPromise = assert.rejects(
+    invitePromise,
+    'invite promise rejects when peer disconnects'
+  )
+  const invite = await inviteReceivedPromise
+  const assertAcceptRejectsPromise = assert.rejects(
+    () => joiner.invite.accept(invite),
+    'accepting invite rejects when project details are not received'
+  )
+  await disconnectPeers()
+  // Run down the timeout waiting for project details
+  clock.runAll()
+  await Promise.all([assertInviteRejectsPromise, assertAcceptRejectsPromise])
+})
 
 test('Attempting to accept unknown inviteId throws', async (t) => {
   const [creator, joiner] = await createManagers(2, t)


### PR DESCRIPTION
fix #1022 

- inviter waits for initial sync before considering the accepted invite to be a success
- inviter sets the member as "left" if the initial sync failed
- inviters can now safely try again and both sides will know the invite failed
- updated unexpected disconnect test since it's more reliable now

I'm actually pretty happy with this outcome! This doesn't auto-retry but it makes sure the inviter knows it fails and resets the member to a state where they can try inviting them again.

Sadly I wasn't as aware of how roles worked two weeks ago and wasn't aware this fix was an option