### PR TITLE
chore: Bump @comapeo/schema dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "^1.6.0",
+        "@comapeo/schema": "1.6.0",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",
@@ -69,7 +69,7 @@
         "@comapeo/core2.0.1": "npm:@comapeo/core@2.0.1",
         "@comapeo/ipc": "^2.1.0",
         "@mapeo/default-config": "5.0.0",
-        "@mapeo/mock-data": "^2.1.5",
+        "@mapeo/mock-data": "^3.0.0",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/b4a": "^1.6.0",
         "@types/bogon": "^1.0.2",
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.4.0.tgz",
-      "integrity": "sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
       "dev": true,
       "funding": [
         {
@@ -1067,22 +1067,21 @@
       "dev": true
     },
     "node_modules/@mapeo/mock-data": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@mapeo/mock-data/-/mock-data-2.1.5.tgz",
-      "integrity": "sha512-pYFpQ3EJMPtEchftz++T8Cr6huSVMb2LS8LmOKmMSEj2XQDfy4XED+BsG6xww4ykILL5Me64AinYCMEBmgYWIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapeo/mock-data/-/mock-data-3.0.0.tgz",
+      "integrity": "sha512-0y9pj6hUGjIkfgVt6Xpdhh3kJYtONdXf3q2FQisfGq2aO9IadzviNF3VvvIWz1oMAGfUKzr1UC6lgDnu2h01YA==",
       "dev": true,
       "dependencies": {
-        "@faker-js/faker": "^9.2.0",
+        "@faker-js/faker": "^9.7.0",
         "dereference-json-schema": "^0.2.1",
-        "json-schema-faker": "^0.5.8",
-        "type-fest": "^4.29.1"
+        "json-schema-faker": "^0.5.9"
       },
       "bin": {
         "generate-mapeo-data": "bin/generate-mapeo-data.js",
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.4.1"
+        "@comapeo/schema": "^1.6.0"
       }
     },
     "node_modules/@mapeo/sqlite-indexer": {
@@ -5895,13 +5894,13 @@
       "license": "MIT"
     },
     "node_modules/json-schema-faker": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.8.tgz",
-      "integrity": "sha512-sqzPEbEDlpiH8U1tfmJHScXHy52onvMxITPsHyhe/jhS83g8TX6ruvRqt/ot1bXUPRsh7Ps1sWqJiBxIXmW5Xw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.9.tgz",
+      "integrity": "sha512-fNKLHgDvfGNNTX1zqIjqFMJjCLzJ2kvnJ831x4aqkAoeE4jE2TxvpJdhOnk3JU3s42vFzmXvkpbYzH5H3ncAzg==",
       "dev": true,
       "dependencies": {
         "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^10.1.0"
+        "jsonpath-plus": "^10.3.0"
       },
       "bin": {
         "jsf": "bin/gen.cjs"
@@ -5983,9 +5982,9 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
       "dev": true,
       "dependencies": {
         "@jsep-plugin/assignment": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "1.5.0",
+        "@comapeo/schema": "^1.6.0",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",
@@ -510,9 +510,10 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
-      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
+      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
+      "license": "MIT",
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
         "compact-encoding": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "1.5.0",
+    "@comapeo/schema": "^1.6.0",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@comapeo/core2.0.1": "npm:@comapeo/core@2.0.1",
     "@comapeo/ipc": "^2.1.0",
     "@mapeo/default-config": "5.0.0",
-    "@mapeo/mock-data": "^2.1.5",
+    "@mapeo/mock-data": "^3.0.0",
     "@sinonjs/fake-timers": "^10.0.2",
     "@types/b4a": "^1.6.0",
     "@types/bogon": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "^1.6.0",
+    "@comapeo/schema": "1.6.0",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",


### PR DESCRIPTION
For some reason this doesn't cause a db migration. It might be due to the new field being a deeply nested optional subfield.

Is it okay to just bump the dep without a migration here? Or should we somehow force it?