### PR TITLE
feat!: update @comapeo/schema to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "1.6.0",
+        "@comapeo/schema": "1.7.0",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",
@@ -818,10 +818,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
-      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
-      "license": "MIT",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.7.0.tgz",
+      "integrity": "sha512-xsu2meZTLeVh7MNy0v/WDz4FPdkr2uwA3gHLvjzf8RsfNh5N/dzzmtbj92EIjLBECQ+YQ1ZRmabhbxnTgEZ7sA==",
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
         "compact-encoding": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "1.6.0",
+    "@comapeo/schema": "1.7.0",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",

--- a/src/blob-api.js
+++ b/src/blob-api.js
@@ -5,34 +5,8 @@ import { createHash, randomBytes } from 'node:crypto'
 /** @import { BlobId, BlobType } from './types.js' */
 
 /**
- * Location coordinate data. Based on [Expo's `LocationObjectCoords`][0].
- * [0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobjectcoords
- *
- * @typedef {object} LocationObjectCoords
- * @prop {number | null} accuracy
- * @prop {number | null} altitude
- * @prop {number | null} altitudeAccuracy
- * @prop {number | null} heading
- * @prop {number} latitude
- * @prop {number} longitude
- * @prop {number | null} speed
- */
-
-/**
- * Location metadata for a blob. Based on [Expo's `LocationObject`][0].
- * [0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobject
- *
- * @typedef {object} LocationObject
- * @prop {LocationObjectCoords} coords
- * @prop {boolean} [mocked]
- * @prop {number} timestamp
- */
-
-/**
  * @typedef {object} Metadata
  * @prop {string} mimeType
- * @prop {number} timestamp
- * @prop {LocationObject} [location]
  */
 
 export class BlobApi {

--- a/test-e2e/manager-fastify-server.js
+++ b/test-e2e/manager-fastify-server.js
@@ -12,7 +12,6 @@ import Fastify from 'fastify'
 
 import { MapeoManager } from '../src/mapeo-manager.js'
 import { FastifyController } from '../src/fastify-controller.js'
-import { blobMetadata } from '../test/helpers/blob-store.js'
 
 const BLOB_FIXTURES_DIR = fileURLToPath(
   new URL('../test/fixtures/blob-api/', import.meta.url)
@@ -140,7 +139,7 @@ test('retrieving blobs using url', async (t) => {
   await t.test('blob exists', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'original.png') },
-      blobMetadata({ mimeType: 'image/png' })
+      { mimeType: 'image/png' }
     )
 
     const blobUrl = await project.$blobs.getUrl({
@@ -304,7 +303,7 @@ test('retrieving audio file', async (t) => {
   await t.test('creating audio', async () => {
     const blobId = await project.$blobs.create(
       { original: join(BLOB_FIXTURES_DIR, 'audio.mp3') },
-      blobMetadata({ mimeType: 'audio/mpeg' })
+      { mimeType: 'audio/mpeg' }
     )
     const blobUrl = await project.$blobs.getUrl({
       ...blobId,

--- a/test-e2e/project-export.js
+++ b/test-e2e/project-export.js
@@ -14,7 +14,6 @@ import { createReadStream } from 'node:fs'
 
 import { MapeoManager } from '../src/mapeo-manager.js'
 import { kGeoJSONFileName, kExportGeoJSONStream } from '../src/mapeo-project.js'
-import { blobMetadata } from '../test//helpers/blob-store.js'
 
 /** @import { Readable } from 'streamx' */
 
@@ -273,7 +272,7 @@ async function setupProject(
         preview: join(BLOB_FIXTURES, 'preview.png'),
         thumbnail: join(BLOB_FIXTURES, 'thumbnail.png'),
       },
-      blobMetadata({ mimeType: 'image/png' })
+      { mimeType: 'image/png' }
     )
 
     attachment = { hash, type, name, driveDiscoveryId: driveId }

--- a/test-e2e/sync.js
+++ b/test-e2e/sync.js
@@ -27,7 +27,6 @@ import { valueOf } from '../src/utils.js'
 import pTimeout from 'p-timeout'
 import { BLOCKED_ROLE_ID, COORDINATOR_ROLE_ID } from '../src/roles.js'
 import { kSyncState } from '../src/sync/sync-api.js'
-import { blobMetadata } from '../test/helpers/blob-store.js'
 import { createHash } from 'node:crypto'
 import { pipeline } from 'node:stream/promises'
 /** @import { State } from '../src/sync/sync-api.js' */
@@ -581,7 +580,7 @@ test('auto-stop', async (t) => {
   ).pathname
   const blob = await invitorProject.$blobs.create(
     { original: fixturePath },
-    blobMetadata({ mimeType: 'image/jpeg' })
+    { mimeType: 'image/jpeg' }
   )
   await waitForSync(projects, 'full')
   const blobUrl = await inviteeProject.$blobs.getUrl({

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -885,7 +885,6 @@ export async function seedProjectBlobs(project, t, { photoCount, audioCount }) {
     const mimeType = type === 'photo' ? 'image/jpeg' : 'audio/mpeg'
     const blobId = await project.$blobs.create(filepaths, {
       mimeType,
-      timestamp: randomDate().valueOf(),
     })
     // @ts-expect-error - TS doesn't know
     output.push({ blobId, hashes })

--- a/test/blob-api.js
+++ b/test/blob-api.js
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto'
 import { fileURLToPath } from 'url'
 import { BlobApi } from '../src/blob-api.js'
 
-import { createBlobStore, blobMetadata } from './helpers/blob-store.js'
+import { createBlobStore } from './helpers/blob-store.js'
 
 test('create blobs', async () => {
   const { blobStore } = createBlobStore()
@@ -31,7 +31,7 @@ test('create blobs', async () => {
       preview: join(directory, 'preview.png'),
       thumbnail: join(directory, 'thumbnail.png'),
     },
-    blobMetadata({ mimeType: 'image/png' })
+    { mimeType: 'image/png' }
   )
 
   assert.equal(attachment.driveId, blobStore.writerDriveId)

--- a/test/helpers/blob-store.js
+++ b/test/helpers/blob-store.js
@@ -34,25 +34,3 @@ export async function concat(rs) {
   )
   return buf
 }
-
-/**
- * @param {Partial<Metadata>} overrides
- * @returns {Metadata}
- */
-export const blobMetadata = (overrides) => ({
-  mimeType: 'image/png',
-  timestamp: Date.now(),
-  location: {
-    coords: {
-      accuracy: 3,
-      altitude: 8848,
-      altitudeAccuracy: 3,
-      heading: 180,
-      latitude: 27.988333,
-      longitude: 86.925278,
-      speed: 0,
-    },
-    timestamp: Date.now(),
-  },
-  ...overrides,
-})


### PR DESCRIPTION
`@comapeo/schema` introduces new fields for the observation attachments: `createdAt` and `position`. These are meant to replace the `timestamp` and `location` blob metadata fields there were part of the `BlobApi`. This PR also updates the `BlobApi` to remove those types as accepted fields in the metadata parameter when creating a blob, hence the breaking change annotation.