### PR TITLE
fix: catch race condition in server remove

### DIFF
--- a/src/member-api.js
+++ b/src/member-api.js
@@ -472,6 +472,7 @@ export class MemberApi extends TypedEmitter {
       )
     }
 
+    const onClosePromise = pEvent(websocket, 'close')
     const onErrorPromise = pEvent(websocket, 'error')
 
     const replicationStream = this.#getReplicationStream()
@@ -494,7 +495,6 @@ export class MemberApi extends TypedEmitter {
       websocket.close()
       throw errorEvent.error
     } else {
-      const onClosePromise = pEvent(websocket, 'close')
       onErrorPromise.cancel()
       websocket.close()
       await onClosePromise


### PR DESCRIPTION
This should fix https://github.com/digidem/comapeo-core/issues/1034

The issue was we weren't catching the socket closing right as replication finishes.