### PR TITLE
chore: Update comapeo/cloud to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.26.1",
-        "@comapeo/cloud": "^0.1.0",
+        "@comapeo/cloud": "^0.2.0",
         "@comapeo/core2.0.1": "npm:@comapeo/core@2.0.1",
         "@comapeo/ipc": "^2.1.0",
         "@mapeo/default-config": "5.0.0",
@@ -259,13 +259,15 @@
       }
     },
     "node_modules/@comapeo/cloud": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/cloud/-/cloud-0.1.0.tgz",
-      "integrity": "sha512-60UNyOoz2+rGKDOtalkAzGnlHnOVBZrHplppaJaLc81qsP3hL8tFhlOUYAroR+WORhc/Ju/3UYslL5MIocq29A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/cloud/-/cloud-0.2.0.tgz",
+      "integrity": "sha512-v35P7LUcW5buQiJ4Byb7QofmMJmWUH+zcxGV45Q8fpjW+elNS1X5ITbHLZzRd62+WUj+gaf/gARVKNSwnlju3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@comapeo/core": "^2.1.0",
+        "@comapeo/core": "^4.1.0",
         "@fastify/sensible": "^5.6.0",
+        "@fastify/type-provider-typebox": "^4.1.0",
         "@fastify/websocket": "^10.0.1",
         "@mapeo/crypto": "^1.0.0-alpha.10",
         "@sinclair/typebox": "^0.33.17",
@@ -275,12 +277,76 @@
         "ws": "^8.18.0"
       }
     },
+    "node_modules/@comapeo/cloud/node_modules/@comapeo/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-1aqc/pHzI8u1dmYazOMSW+tUkG7vDcHococr+1Ul3rdWpUiZIlmk0kYzdLtl6gc7sWi7CqxloqglrKPIHXKfOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@comapeo/fallback-smp": "^1.0.0",
+        "@comapeo/schema": "2.0.0",
+        "@digidem/types": "^2.3.0",
+        "@fastify/error": "^3.4.1",
+        "@fastify/type-provider-typebox": "^4.1.0",
+        "@hyperswarm/secret-stream": "^6.6.3",
+        "@mapeo/crypto": "1.0.0-alpha.10",
+        "@mapeo/sqlite-indexer": "1.0.0-alpha.9",
+        "@sinclair/typebox": "^0.33.17",
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "b4a": "^1.6.3",
+        "bcp-47": "^2.1.0",
+        "better-sqlite3": "^8.7.0",
+        "big-sparse-array": "^1.0.3",
+        "bogon": "^1.1.0",
+        "compact-encoding": "^2.12.0",
+        "corestore": "6.8.4",
+        "debug": "^4.3.4",
+        "dot-prop": "^9.0.0",
+        "drizzle-orm": "^0.30.8",
+        "ensure-error": "^4.0.0",
+        "fastify": "^4.0.0",
+        "fastify-plugin": "^4.5.1",
+        "hyperblobs": "2.3.0",
+        "hypercore": "10.19.0",
+        "hypercore-crypto": "3.4.2",
+        "hyperdrive": "11.5.3",
+        "json-stable-stringify": "^1.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "map-obj": "^5.0.2",
+        "mime": "^4.0.7",
+        "multi-core-indexer": "^1.0.0",
+        "p-defer": "^4.0.0",
+        "p-event": "^6.0.1",
+        "p-timeout": "^6.1.2",
+        "protobufjs": "^7.2.3",
+        "protomux": "^3.4.1",
+        "quickbit-universal": "^2.2.0",
+        "sodium-universal": "^4.0.0",
+        "start-stop-state-machine": "^1.2.0",
+        "streamx": "^2.19.0",
+        "string-timing-safe-equal": "^0.1.0",
+        "styled-map-package": "^3.0.0",
+        "sub-encoder": "^2.1.1",
+        "throttle-debounce": "^5.0.0",
+        "tiny-typed-emitter": "^2.1.0",
+        "type-fest": "^4.30.0",
+        "undici": "^6.13.0",
+        "unix-path-resolve": "^1.0.2",
+        "varint": "^6.0.0",
+        "ws": "^8.18.0",
+        "xstate": "^5.19.2",
+        "yauzl-promise": "^4.0.0",
+        "zip-stream-promise": "^1.0.2"
+      }
+    },
     "node_modules/@comapeo/core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@comapeo/core/-/core-2.3.0.tgz",
       "integrity": "sha512-yH/GOKMGSRNbdo4mKf+XXw7TGzdK+e4Ze9QfojhKs2Gdmq6uXMGp74XbUBUyzLKxiUnYCyOM0dPIyQR+i08yqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
         "@comapeo/schema": "1.3.0",
@@ -341,6 +407,7 @@
       "integrity": "sha512-+rDgfKahCbUk5bU6BBcCQ3aMSRJfenkbYET0PdN4sg2c+G3BOELaTI5+s5n+oZQEEOxYXp3UDkT61PlA2nUPQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.0",
         "compact-encoding": "^2.12.0",
@@ -353,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-12.1.0.tgz",
       "integrity": "sha512-wf/lwQvWAA0goIghcb91dQYpkLBcyhOhQNqG/VgWhnKzgt+UOMvra7EX/2fv70arm5RW+PUHoQHHDa6/p77Eqg==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "commander": "~12.1.0"
       }
@@ -362,7 +430,8 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.29.6.tgz",
       "integrity": "sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@comapeo/core/node_modules/buffer": {
       "version": "6.0.3",
@@ -383,6 +452,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -393,6 +463,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
       "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -405,6 +476,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -414,6 +486,7 @@
       "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.17.0.tgz",
       "integrity": "sha512-Yp9lyfUjp81Gy1nPHemNFtYQtngliCGZ6prH+qxvjr2FPVG1QFtNqtOh+ZxFu4hXZ1dAOLYkQOA7Qq2vjFe64A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
@@ -440,6 +513,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -452,6 +526,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
       "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^1.1.1"
       },
@@ -467,6 +542,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -483,6 +559,7 @@
       "resolved": "https://registry.npmjs.org/styled-map-package/-/styled-map-package-2.2.1.tgz",
       "integrity": "sha512-RTA+PBOu44A0bt+Zv/TkEZMLiNkLIA/v/AHh5PTzqb86Q0zB9aF7n27Lz7/SNPAOE4fahENbajX5IfrZbCTQUA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
         "@fastify/static": "^7.0.4",
@@ -527,6 +604,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
       "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "homepage": "https://github.com/digidem/comapeo-core#readme",
   "devDependencies": {
     "@bufbuild/buf": "^1.26.1",
-    "@comapeo/cloud": "^0.1.0",
+    "@comapeo/cloud": "^0.2.0",
     "@comapeo/core2.0.1": "npm:@comapeo/core@2.0.1",
     "@comapeo/ipc": "^2.1.0",
     "@mapeo/default-config": "5.0.0",


### PR DESCRIPTION
Should fix the e2e-cloud CI fails

One thing I'm unsure about is whether it's an issue that the package lock now adds a reference to the module itself. Is there something we should do about that?