### PR TITLE
fix: Reuse port for discovery server

### DIFF
--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -471,6 +471,26 @@ test('Consistent storage folders', async () => {
   )
 })
 
+test('Reusing port after start/stop of discovery', async (t) => {
+  const manager = new MapeoManager({
+    rootKey: KeyManager.generateRootKey(),
+    projectMigrationsFolder,
+    clientMigrationsFolder,
+    dbFolder: ':memory:',
+    coreStorage: () => new RAM(),
+    fastify: Fastify(),
+  })
+
+  t.after(() => manager.stopLocalPeerDiscoveryServer())
+
+  const { port } = await manager.startLocalPeerDiscoveryServer()
+
+  await manager.stopLocalPeerDiscoveryServer({ force: true })
+
+  const { port: newPort } = await manager.startLocalPeerDiscoveryServer()
+  assert.equal(newPort, port, 'Port got reused')
+})
+
 /**
  * Generate a deterministic random bytes
  *


### PR DESCRIPTION
We could be running issues with MDNS caches not being updated with the new port.
With this a run of the app will preserve a port between going in and out of the background. Also added a test to use a new port if binding on the current port fails.