### PR TITLE
fix: turn off debug logging for indexing and sync

### DIFF
--- a/src/index-writer/index.js
+++ b/src/index-writer/index.js
@@ -97,16 +97,18 @@ export class IndexWriter {
       const indexer = this.#indexers.get(schemaName)
       if (!indexer) continue // Won't happen, but TS doesn't know that
       indexer.batch(docs)
-      if (this.#l.log.enabled) {
-        for (const doc of docs) {
-          this.#l.log(
-            'Indexed %s %S @ %S',
-            doc.schemaName,
-            doc.docId,
-            doc.versionId
-          )
-        }
-      }
+      // TODO: selectively turn this on when log level is 'trace' or 'debug'
+      // Otherwise this has a big performance overhead because this is all synchronous
+      // if (this.#l.log.enabled) {
+      //   for (const doc of docs) {
+      //     this.#l.log(
+      //       'Indexed %s %S @ %S',
+      //       doc.schemaName,
+      //       doc.docId,
+      //       doc.versionId
+      //     )
+      //   }
+      // }
     }
     return indexed
   }

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -132,7 +132,9 @@ export class PeerSyncController {
     const localState = mapObject(state, (ns, nsState) => {
       return [ns, nsState.localState]
     })
-    this.#log('state %X', state)
+    // TODO: Turn this on when log level is 'trace' or 'debug'
+    // This logs _a lot_ of data, which has a performance overhead
+    // this.#log('state %X', state)
 
     // Map of which namespaces have received new data since last sync change
     const didUpdate = mapObject(state, (ns) => {


### PR DESCRIPTION
Logging these events produces a lot of output, which has a performance overhead. We need debug logging for debugging other issues, and currently we don't have a way to set log levels to selectively log this, so turning this off for now until we can filter logs by level.