### PR TITLE
chore: add explicit type exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,15 +7,46 @@ import { kProjectReplicate } from './mapeo-project.js'
 export { plugin as CoMapeoMapsFastifyPlugin } from './fastify-plugins/maps.js'
 export { FastifyController } from './fastify-controller.js'
 export { MapeoManager } from './mapeo-manager.js'
-/** @import { MapeoProject } from './mapeo-project.js' */
 
+// Type exports
+/** @typedef {import('./mapeo-project.js').MapeoProject} MapeoProject */
+/** @typedef {import('./mapeo-project.js').EditableProjectSettings} EditableProjectSettings */
+/**
+ * @namespace IconApi
+ * @typedef {import('./icon-api.js').BitmapOpts} IconApi.BitmapOpts
+ * @typedef {import('./icon-api.js').SvgOpts} IconApi.SvgOpts
+ */
+/**
+ * @namespace BlobApi
+ * @typedef {import('./types.js').BlobId} BlobApi.BlobId
+ * @typedef {import('./blob-api.js').Metadata} BlobApi.Metadata
+ */
+// This needs to be defined in a separate comment block so that the @template definition works.
+/**
+ * @template {import('./types.js').BlobType} TBlobType
+ * @typedef {import('./types.js').BlobVariant<TBlobType>} BlobApi.BlobVariant
+ */
+/**
+ * @namespace InviteApi
+ * @typedef {import('./invite/invite-api.js').Invite} InviteApi.Invite
+ */
+/**
+ * @namespace MemberApi
+ * @typedef {import('./member-api.js').MemberInfo} MemberApi.MemberInfo
+ * @typedef {import('./roles.js').RoleId} MemberApi.RoleId
+ * @typedef {import('./roles.js').RoleIdForNewInvite} MemberApi.RoleIdForNewInvite
+ */
 /**
  * @param {MapeoProject} project
- * @param {Parameters<MapeoProject.prototype[kProjectReplicate]>} args
- * @returns {ReturnType<MapeoProject.prototype[kProjectReplicate]>}
+ * @param {(
+ *   boolean |
+ *   import('stream').Duplex |
+ *   import('streamx').Duplex
+ * )} isInitiatorOrStream
+ * @returns {import('./types.js').ReplicationStream}
  */
-export const replicateProject = (project, ...args) =>
-  project[kProjectReplicate](...args)
+export const replicateProject = (project, isInitiatorOrStream) =>
+  project[kProjectReplicate](isInitiatorOrStream)
 
 export const roles = /** @type {const} */ ({
   CREATOR_ROLE_ID,


### PR DESCRIPTION
These are the types currently used by
dependencies, and are currently imported from
source files, which is liable to break if we
refactor code. Dependencies should be updated to
use these exports from the main entry point.