### PR TITLE
fix: pin @comapeo/schema dep to exact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@comapeo/fallback-smp": "^1.0.0",
-        "@comapeo/schema": "^2.1.1",
+        "@comapeo/schema": "2.1.1",
         "@digidem/types": "^2.3.0",
         "@fastify/error": "^3.4.1",
         "@fastify/type-provider-typebox": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   },
   "dependencies": {
     "@comapeo/fallback-smp": "^1.0.0",
-    "@comapeo/schema": "^2.1.1",
+    "@comapeo/schema": "2.1.1",
     "@digidem/types": "^2.3.0",
     "@fastify/error": "^3.4.1",
     "@fastify/type-provider-typebox": "^4.1.0",


### PR DESCRIPTION
Small regression introduced in #1098 ([here](https://github.com/digidem/comapeo-core/pull/1098/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L165)). From what I understand, we generally pin the dep at an exact version to avoid potential issues related to types resolution (not sure about runtime issues)