### PR TITLE
chore: fix auth issue for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: nearform-actions/optic-release-automation-action@a2785548e8bdafab7e628c2317b604278e460434 # v4.12.2
         with:


### PR DESCRIPTION
Missed one of the steps documented in the action's [docs](https://optic.nearform.com/docs/github-action/publish-modes#oidc-trusted-publishing) that's required for using OIDC for publishing.