### PR TITLE
fix: Rework initial settings storage on invitee v2

### DIFF
--- a/drizzle/client/0004_curious_abomination.sql
+++ b/drizzle/client/0004_curious_abomination.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `backupProjectInfo` (
+	`projectId` text PRIMARY KEY NOT NULL,
+	`projectName` text NOT NULL,
+	`projectDescription` text
+);

--- a/drizzle/client/0004_fresh_pestilence.sql
+++ b/drizzle/client/0004_fresh_pestilence.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `backupProjectInfo` (
 	`projectId` text PRIMARY KEY NOT NULL,
 	`projectName` text NOT NULL,
-	`projectDescription` text
+	`projectDescription` text,
+	`sendStats` integer DEFAULT false NOT NULL
 );

--- a/drizzle/client/0005_military_paper_doll.sql
+++ b/drizzle/client/0005_military_paper_doll.sql
@@ -1,0 +1,2 @@
+DROP TABLE `backupProjectInfo`;--> statement-breakpoint
+ALTER TABLE projectKeys ADD `hasLeftProject` integer DEFAULT false NOT NULL;

--- a/drizzle/client/meta/0004_snapshot.json
+++ b/drizzle/client/meta/0004_snapshot.json
@@ -1,0 +1,257 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "4695b766-f079-40fe-b858-90e36d8b0cad",
+  "prevId": "3b7b9e2d-3a35-47e3-977e-b5dcbe2fd302",
+  "tables": {
+    "backupProjectInfo": {
+      "name": "backupProjectInfo",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectDescription": {
+          "name": "projectDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deviceSettings": {
+      "name": "deviceSettings",
+      "columns": {
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isArchiveDevice": {
+          "name": "isArchiveDevice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deviceSettings_deviceId_unique": {
+          "name": "deviceSettings_deviceId_unique",
+          "columns": [
+            "deviceId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings_backlink": {
+      "name": "projectSettings_backlink",
+      "columns": {
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectKeys": {
+      "name": "projectKeys",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectPublicId": {
+          "name": "projectPublicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInviteId": {
+          "name": "projectInviteId",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keysCipher": {
+          "name": "keysCipher",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInfo": {
+          "name": "projectInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings": {
+      "name": "projectSettings",
+      "columns": {
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalVersionId": {
+          "name": "originalVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schemaName": {
+          "name": "schemaName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectDescription": {
+          "name": "projectDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectColor": {
+          "name": "projectColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sendStats": {
+          "name": "sendStats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defaultPresets": {
+          "name": "defaultPresets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configMetadata": {
+          "name": "configMetadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forks": {
+          "name": "forks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/client/meta/0004_snapshot.json
+++ b/drizzle/client/meta/0004_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "sqlite",
-  "id": "4695b766-f079-40fe-b858-90e36d8b0cad",
+  "id": "ac5d31dc-4925-4afd-944c-4dddd7dd21c5",
   "prevId": "3b7b9e2d-3a35-47e3-977e-b5dcbe2fd302",
   "tables": {
     "backupProjectInfo": {
@@ -27,6 +27,14 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "sendStats": {
+          "name": "sendStats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
         }
       },
       "indexes": {},

--- a/drizzle/client/meta/0005_snapshot.json
+++ b/drizzle/client/meta/0005_snapshot.json
@@ -1,0 +1,235 @@
+{
+  "version": "5",
+  "dialect": "sqlite",
+  "id": "51b9a2b4-828f-4527-ab1c-a16b8a818085",
+  "prevId": "ac5d31dc-4925-4afd-944c-4dddd7dd21c5",
+  "tables": {
+    "deviceSettings": {
+      "name": "deviceSettings",
+      "columns": {
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceInfo": {
+          "name": "deviceInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isArchiveDevice": {
+          "name": "isArchiveDevice",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deviceSettings_deviceId_unique": {
+          "name": "deviceSettings_deviceId_unique",
+          "columns": [
+            "deviceId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings_backlink": {
+      "name": "projectSettings_backlink",
+      "columns": {
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectKeys": {
+      "name": "projectKeys",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectPublicId": {
+          "name": "projectPublicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInviteId": {
+          "name": "projectInviteId",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keysCipher": {
+          "name": "keysCipher",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projectInfo": {
+          "name": "projectInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{\"sendStats\":false}'"
+        },
+        "hasLeftProject": {
+          "name": "hasLeftProject",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projectSettings": {
+      "name": "projectSettings",
+      "columns": {
+        "docId": {
+          "name": "docId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "versionId": {
+          "name": "versionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "originalVersionId": {
+          "name": "originalVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schemaName": {
+          "name": "schemaName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectDescription": {
+          "name": "projectDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "projectColor": {
+          "name": "projectColor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sendStats": {
+          "name": "sendStats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "defaultPresets": {
+          "name": "defaultPresets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configMetadata": {
+          "name": "configMetadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forks": {
+          "name": "forks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -33,8 +33,8 @@
     {
       "idx": 4,
       "version": "5",
-      "when": 1758575697167,
-      "tag": "0004_curious_abomination",
+      "when": 1758640418795,
+      "tag": "0004_fresh_pestilence",
       "breakpoints": true
     }
   ]

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1756331824879,
       "tag": "0003_neat_magus",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1758575697167,
+      "tag": "0004_curious_abomination",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/client/meta/_journal.json
+++ b/drizzle/client/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1758640418795,
       "tag": "0004_fresh_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1758807178583,
+      "tag": "0005_military_paper_doll",
+      "breakpoints": true
     }
   ]
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,3 @@ export const SUPPORTED_CONFIG_VERSION = 1
 
 // WARNING: This value is persisted. Be careful when changing it.
 export const DRIZZLE_MIGRATIONS_TABLE = '__drizzle_migrations'
-
-// Oldest possible time, ensure it gets overwritten with any updates
-export const UNIX_EPOCH_DATE = new Date(0).toISOString()

--- a/src/invite/invite-api.js
+++ b/src/invite/invite-api.js
@@ -126,6 +126,7 @@ export class InviteApi extends TypedEmitter {
       projectName,
       projectColor,
       projectDescription,
+      sendStats,
     } = inviteRpcMessage
     const invite = { ...inviteRpcMessage, receivedAt: Date.now() }
 
@@ -161,6 +162,7 @@ export class InviteApi extends TypedEmitter {
               projectName,
               projectColor,
               projectDescription,
+              sendStats,
             })
           }),
         },

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -23,6 +23,7 @@ import {
   deviceSettingsTable,
   projectKeysTable,
   projectSettingsTable,
+  backupProjectInfoTable,
 } from './schema/client.js'
 import { ProjectKeys } from './generated/keys.js'
 import {
@@ -654,23 +655,14 @@ export class MapeoManager extends TypedEmitter {
     try {
       project = await this.getProject(projectPublicId)
 
-      /** @type {import('drizzle-orm').InferInsertModel<typeof projectSettingsTable>} */
-      const settingsDoc = {
-        schemaName: 'projectSettings',
-        docId: projectId,
-        versionId: 'unknown',
-        originalVersionId: 'unknown',
-        createdAt: UNIX_EPOCH_DATE,
-        updatedAt: UNIX_EPOCH_DATE,
-        deleted: false,
-        sendStats: false,
-        links: [],
-        forks: [],
+      /** @type {import('drizzle-orm').InferInsertModel<typeof backupProjectInfoTable>} */
+      const backupProjectInfo = {
+        projectId,
         name: projectName,
         projectDescription,
       }
 
-      await this.#db.insert(projectSettingsTable).values([settingsDoc])
+      await this.#db.insert(backupProjectInfoTable).values([backupProjectInfo])
       this.#activeProjects.set(projectPublicId, project)
     } catch (e) {
       // Only happens if getProject or the the DB insert fails

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -66,7 +66,7 @@ import { WebSocket } from 'ws'
 /** @import { DeviceInfoParam, ProjectInfo } from './schema/client.js' */
 
 /** @typedef {SetNonNullable<ProjectKeys, 'encryptionKeys'>} ValidatedProjectKeys */
-/** @typedef {Pick<ProjectJoinDetails, 'projectKey' | 'encryptionKeys'> & { projectName: string, projectColor?: string, projectDescription?: string }} ProjectToAddDetails */
+/** @typedef {Pick<ProjectJoinDetails, 'projectKey' | 'encryptionKeys'> & { projectName: string, projectColor?: string, projectDescription?: string, sendStats?: boolean }} ProjectToAddDetails */
 /** @typedef {{ projectId: string, createdAt?: string, updatedAt?: string, name?: string, projectColor?: string, projectDescription?: string }} ListedProject */
 
 const CLIENT_SQLITE_FILE_NAME = 'client.db'
@@ -619,6 +619,7 @@ export class MapeoManager extends TypedEmitter {
       projectName,
       projectColor,
       projectDescription,
+      sendStats = false,
     },
     { waitForSync = true } = {}
   ) => {
@@ -671,6 +672,7 @@ export class MapeoManager extends TypedEmitter {
         projectId,
         name: projectName,
         projectDescription,
+        sendStats,
       }
 
       await this.#db.insert(backupProjectInfoTable).values([backupProjectInfo])

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -39,7 +39,6 @@ import {
   projectKeyToProjectInviteId,
   projectKeyToPublicId,
 } from './utils.js'
-import { UNIX_EPOCH_DATE } from './constants.js'
 import { openedNoiseSecretStream } from './lib/noise-secret-stream-helpers.js'
 import { omit } from './lib/omit.js'
 import { RandomAccessFilePool } from './core-manager/random-access-file-pool.js'
@@ -577,8 +576,8 @@ export class MapeoManager extends TypedEmitter {
       result.push(
         deNullify({
           projectId: projectPublicId,
-          createdAt: ignoreUnixDate(existingProject?.createdAt),
-          updatedAt: ignoreUnixDate(existingProject?.updatedAt),
+          createdAt: existingProject?.createdAt,
+          updatedAt: existingProject?.updatedAt,
           name: existingProject?.name || projectInfo.name,
           projectColor:
             existingProject?.projectColor || projectInfo.projectColor,
@@ -1032,14 +1031,4 @@ function validateProjectKeys(projectKeys) {
  */
 function hasSavedDeviceInfo(partialDeviceInfo) {
   return Boolean(partialDeviceInfo.name)
-}
-
-/**
- * @param {string|undefined} date
- * @returns {string|null}
- */
-function ignoreUnixDate(date) {
-  if (date === UNIX_EPOCH_DATE) return null
-  if (date === undefined) return null
-  return date
 }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -11,7 +11,7 @@ import mime from 'mime/lite'
 // @ts-expect-error
 import { Readable, pipelinePromise } from 'streamx'
 
-import { NAMESPACES, NAMESPACE_SCHEMAS, UNIX_EPOCH_DATE } from './constants.js'
+import { NAMESPACES, NAMESPACE_SCHEMAS } from './constants.js'
 import { CoreManager } from './core-manager/index.js'
 import { DataStore } from './datastore/index.js'
 import { DataType, kCreateWithDocId } from './datatype/index.js'
@@ -706,11 +706,9 @@ export class MapeoProject extends TypedEmitter {
    */
   async $hasSyncedProjectSettings() {
     try {
-      const settings = await this.#dataTypes.projectSettings.getByDocId(
-        this.#projectId
-      )
-
-      return settings.createdAt !== UNIX_EPOCH_DATE
+      // Should error if we haven't synced before
+      await this.#dataTypes.projectSettings.getByDocId(this.#projectId)
+      return true
     } catch (e) {
       return false
     }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -696,7 +696,7 @@ export class MapeoProject extends TypedEmitter {
       return {
         name: backupInfo.name,
         projectDescription: backupInfo.projectDescription ?? undefined,
-        sendStats: false,
+        sendStats: backupInfo.sendStats,
       }
     }
   }

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -226,6 +226,11 @@ export class MapeoProject extends TypedEmitter {
 
     if (reindex) {
       for (const table of indexedTables) db.delete(table).run()
+
+      sharedDb
+        .delete(projectSettingsTable)
+        .where(eq(projectSettingsTable.docId, this.#projectId))
+        .run()
     }
 
     ///////// 3. Setup random-access-storage functions

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -44,6 +44,7 @@ export const backupProjectInfoTable = sqliteTable('backupProjectInfo', {
   projectId: text('projectId').notNull().primaryKey(),
   name: text('projectName').notNull(),
   projectDescription: text('projectDescription'),
+  sendStats: int('sendStats', { mode: 'boolean' }).notNull().default(false),
 })
 
 /**

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -10,7 +10,7 @@ import { backlinkTable, customJson } from './utils.js'
  * @import { ProjectSettings } from '@comapeo/schema'
  *
  * @internal
- * @typedef {Pick<ProjectSettings, 'name' | 'projectColor' | 'projectDescription'>} ProjectInfo
+ * @typedef {Pick<ProjectSettings, 'name' | 'projectColor' | 'projectDescription' | 'sendStats'>} ProjectInfo
  */
 
 const projectInfoColumn =
@@ -19,7 +19,7 @@ const projectInfoColumn =
   )
 
 /** @type {ProjectInfo} */
-const PROJECT_INFO_DEFAULT_VALUE = {}
+const PROJECT_INFO_DEFAULT_VALUE = { sendStats: false }
 
 export const projectSettingsTable = sqliteTable(
   'projectSettings',
@@ -29,7 +29,7 @@ export const projectBacklinkTable = backlinkTable(projectSettingsTable)
 export const projectKeysTable = sqliteTable('projectKeys', {
   projectId: text('projectId').notNull().primaryKey(),
   projectPublicId: text('projectPublicId').notNull(),
-  projectInviteId: blob('projectInviteId').notNull(),
+  projectInviteId: blob('projectInviteId', { mode: 'buffer' }).notNull(),
   keysCipher: blob('keysCipher', { mode: 'buffer' }).notNull(),
   projectInfo: projectInfoColumn('projectInfo')
     .default(
@@ -38,13 +38,9 @@ export const projectKeysTable = sqliteTable('projectKeys', {
       JSON.stringify(PROJECT_INFO_DEFAULT_VALUE)
     )
     .notNull(),
-})
-
-export const backupProjectInfoTable = sqliteTable('backupProjectInfo', {
-  projectId: text('projectId').notNull().primaryKey(),
-  name: text('projectName').notNull(),
-  projectDescription: text('projectDescription'),
-  sendStats: int('sendStats', { mode: 'boolean' }).notNull().default(false),
+  hasLeftProject: int('hasLeftProject', { mode: 'boolean' })
+    .notNull()
+    .default(false),
 })
 
 /**

--- a/src/schema/client.js
+++ b/src/schema/client.js
@@ -40,6 +40,12 @@ export const projectKeysTable = sqliteTable('projectKeys', {
     .notNull(),
 })
 
+export const backupProjectInfoTable = sqliteTable('backupProjectInfo', {
+  projectId: text('projectId').notNull().primaryKey(),
+  name: text('projectName').notNull(),
+  projectDescription: text('projectDescription'),
+})
+
 /**
  * @typedef {Omit<import('@comapeo/schema').DeviceInfoValue, 'schemaName'>} DeviceInfoParam
  */

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -4,6 +4,7 @@ import { randomBytes, createHash } from 'crypto'
 import { KeyManager } from '@mapeo/crypto'
 import RAM from 'random-access-memory'
 import { MapeoManager } from '../src/mapeo-manager.js'
+import { MapeoProject } from '../src/mapeo-project.js'
 import Fastify from 'fastify'
 import { getExpectedConfig } from './utils.js'
 import { defaultConfigPath } from '../test/helpers/default-config.js'
@@ -57,6 +58,9 @@ test('Managing created projects', async (t) => {
 
   assert(project1)
   assert(project2)
+
+  assert(project1 instanceof MapeoProject)
+  assert(project2 instanceof MapeoProject)
 
   await t.test('initial settings from project instances', async () => {
     const settings1 = await project1.$getProjectSettings()

--- a/test-e2e/manager-basic.js
+++ b/test-e2e/manager-basic.js
@@ -43,12 +43,14 @@ test('Managing created projects', async (t) => {
     )
 
     assert(listedProject1)
-    assert(!listedProject1?.name)
+    assert(!listedProject1.name)
+    assert.equal(listedProject1.status, 'joined')
     assert(listedProject1?.createdAt)
     assert(listedProject1?.updatedAt)
 
     assert(listedProject2)
-    assert.equal(listedProject2?.name, 'project 2')
+    assert.equal(listedProject2.name, 'project 2')
+    assert.equal(listedProject2.status, 'joined')
     assert(listedProject2?.createdAt)
     assert(listedProject2?.updatedAt)
   })
@@ -137,6 +139,7 @@ test('Managing created projects', async (t) => {
     )
 
     assert(project1FromListed)
+    assert(project1FromListed.status === 'joined')
 
     const {
       createdAt: project1CreatedAt,
@@ -151,9 +154,12 @@ test('Managing created projects', async (t) => {
       name: 'project 1',
       projectColor: '#123456',
       projectDescription: undefined,
+      sendStats: false,
+      status: 'joined',
     })
 
     assert(project2FromListed)
+    assert.equal(project2FromListed.status, 'joined')
 
     const {
       createdAt: project2CreatedAt,
@@ -168,6 +174,8 @@ test('Managing created projects', async (t) => {
       name: 'project 2 updated',
       projectColor: undefined,
       projectDescription: 'project 2 description',
+      sendStats: false,
+      status: 'joined',
     })
   })
 })
@@ -330,14 +338,16 @@ test('Managing added projects', async (t) => {
     )
 
     assert(listedProject1)
-    assert.equal(listedProject1?.name, 'project 1')
-    assert(!listedProject1?.createdAt)
-    assert(!listedProject1?.updatedAt)
+    assert.equal(listedProject1.name, 'project 1')
+    assert.equal(listedProject1.status, 'joining')
+    assert(!('createdAt' in listedProject1))
+    assert(!('updatedAt' in listedProject1))
 
     assert(listedProject2)
-    assert.equal(listedProject2?.name, 'project 2')
-    assert(!listedProject2?.createdAt)
-    assert(!listedProject2?.updatedAt)
+    assert.equal(listedProject2.name, 'project 2')
+    assert.equal(listedProject2.status, 'joining')
+    assert(!('createdAt' in listedProject2))
+    assert(!('updatedAt' in listedProject2))
   })
 
   await t.test(

--- a/test-e2e/project-settings.js
+++ b/test-e2e/project-settings.js
@@ -1,26 +1,19 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { KeyManager } from '@mapeo/crypto'
-import RAM from 'random-access-memory'
-import Fastify from 'fastify'
 
-import { MapeoManager } from '../src/mapeo-manager.js'
-import { MapeoProject } from '../src/mapeo-project.js'
-import { removeUndefinedFields } from './utils.js'
+import { COORDINATOR_ROLE_ID } from '../src/roles.js'
 
-test('Project settings create, read, and update operations', async () => {
-  const fastify = Fastify()
+import {
+  removeUndefinedFields,
+  createManager,
+  createManagers,
+  invite,
+  waitForSync,
+  connectPeers,
+} from './utils.js'
 
-  const manager = new MapeoManager({
-    rootKey: KeyManager.generateRootKey(),
-    projectMigrationsFolder: new URL('../drizzle/project', import.meta.url)
-      .pathname,
-    clientMigrationsFolder: new URL('../drizzle/client', import.meta.url)
-      .pathname,
-    dbFolder: ':memory:',
-    coreStorage: () => new RAM(),
-    fastify,
-  })
+test('Project settings create, read, and update operations', async (t) => {
+  const manager = createManager('device0', t)
 
   const projectId = await manager.createProject()
 
@@ -31,11 +24,6 @@ test('Project settings create, read, and update operations', async () => {
 
   const project = await manager.getProject(projectId)
 
-  assert(
-    project instanceof MapeoProject,
-    'manager.getProject() returns MapeoProject instance'
-  )
-
   const initialSettings = await project.$getProjectSettings()
 
   assert.deepEqual(
@@ -45,6 +33,56 @@ test('Project settings create, read, and update operations', async () => {
     },
     'project has no settings after creation'
   )
+
+  const expectedSettings = {
+    name: 'updated',
+    projectColor: '#123456',
+    projectDescription: 'cool project',
+  }
+
+  const updatedSettings = await project.$setProjectSettings(expectedSettings)
+
+  assert.equal(
+    updatedSettings.name,
+    expectedSettings.name,
+    'updatable settings change'
+  )
+
+  const settings = await project.$getProjectSettings()
+
+  assert.deepEqual(
+    settings,
+    updatedSettings,
+    'retrieved settings are equivalent to most recently updated'
+  )
+})
+
+test('Set project settings after being invited', async (t) => {
+  const managers = await createManagers(2, t)
+  const [invitor, invitee] = managers
+  const disconnectPeers = connectPeers(managers)
+  t.after(disconnectPeers)
+
+  const projectId = await invitor.createProject({ name: 'Example' })
+
+  await invite({
+    invitor,
+    projectId,
+    invitees: [invitee],
+    roleId: COORDINATOR_ROLE_ID,
+  })
+
+  const project = await invitee.getProject(projectId)
+
+  const initialSettings = await project.$getProjectSettings()
+
+  assert.equal(
+    initialSettings.name,
+    'Example',
+    'Invitee sees name before full sync'
+  )
+
+  await waitForSync([project], 'full')
 
   const expectedSettings = {
     name: 'updated',


### PR DESCRIPTION
This is a rework of #1123, because during review I realised it was not necessary to maintain a separate table because we already store project info in the keys table.

This changes how leaving a project is tracked: it is now written to the project keys table _before_ clearing project data.

A previous fix to ensure data is cleared after leaving a project used the change of role to acertain if the project had been left, however because this check was made every time a project instance was created, including when adding a new project from an invite, it was actually creating a big delay, because a project instance would not be returned until getOwnRole returned, which waited for initial sync.

This adds a `status` prop to the `manager.listProjects()` function to be explicit about when a project is in the "joining" state, and adds an additional "left" status.

There is a change of behaviour here where $getProjectSettings() will still return the basic project info (name, description, color, sendStats) even after leaving a project, which makes it consistent with what is returned from `listProjects()`.

The test for "partly-left projects" should be more robust now too - it doesn't "pretend" to partly leave a project, but instead prematurely exits the process to more realistically simulate what would happen in real usage if leave project fails.

Also fixes a small type bug for the `projectInviteId` column of the projectKeysTable, which was defined as `unknown` because it was defaulting to a JSON column I think.

