### PR TITLE
chore: remove branch filter on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,23 @@ on:
 
 jobs:
   release:
-    if: ${{github.event_name != 'pull_request' || (github.event.pull_request.merged && github.event.pull_request.user.login == 'optic-release-automation[bot]')}}
+    if: >-
+      ${{
+        (
+          startsWith(github.event.inputs.semver, 'pre') ||
+          github.ref == format(
+            'refs/heads/{0}',
+            github.event.repository.default_branch
+          )
+        ) &&
+        (
+          github.event_name != 'pull_request' ||
+          (
+            github.event.pull_request.merged &&
+            github.event.pull_request.user.login == 'optic-release-automation[bot]'
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This removes the branch filter on the release workflow `pull_request` trigger, so that it runs on PRs that do not target the `main` branch.

The reason I would like this is so that I can publish pre-release versions from branches other than main, e.g. right now I have a [PR for comapeocat changes](https://github.com/digidem/comapeo-core/pull/1135), and I would like to release a pre-release without merging it into main. 

This adds an additional condition to the release job running, so that if a user tries to manually dispatch it on not-the-main branch, but when it's not a prerelease, then it will be skipped. You can only do a prerelease on a non-main branch.