### PR TITLE
test: Export on invited peer

### DIFF
--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -314,6 +314,32 @@ export class BlobStore extends TypedEmitter {
   }
 
   /**
+   * Check if all the blocks for a given blob entry have been downloaded
+   * @param {BlobId['driveId']} driveId Hyperdrive drive id
+   * @param {import('hyperdrive').HyperdriveEntry} entry Hyperdrive entry
+   * @returns {Promise<boolean>}
+   */
+  async hasDownloadedBlobEntry(driveId, entry) {
+    const drive = this.#getDrive(driveId)
+    const blobs = await drive.getBlobs()
+
+    if (!blobs) {
+      return false
+    }
+
+    const { blockOffset, blockLength } = entry.value.blob
+
+    const core = blobs.core.session()
+    try {
+      const start = blockOffset
+      const end = blockOffset + blockLength
+      return core.has(start, end)
+    } catch {
+      return false
+    }
+  }
+
+  /**
    *
    * @param {Omit<BlobId, 'driveId'>} blobId
    * @param {Buffer} blob

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -1162,6 +1162,13 @@ export class MapeoProject extends TypedEmitter {
             continue
           }
         }
+        const hasDownloaded = await this.#blobStore.hasDownloadedBlobEntry(
+          blobId.driveId,
+          entry
+        )
+        if (!hasDownloaded) {
+          continue
+        }
         return { blobId, mimeType }
       } catch (e) {
         if (!(e instanceof Error)) throw e

--- a/test-e2e/project-export.js
+++ b/test-e2e/project-export.js
@@ -222,7 +222,10 @@ test('Project export tracks and observations to zip stream', async (t) => {
 })
 
 test('Sync project and export tracks and observations to zip stream', async (t) => {
-  const managers = await createManagers(2, t)
+  const managers = await createManagers(2, t, 'device_type_unspecified', {
+    // Mobile is not archive device by default and we should support that.
+    defaultIsArchiveDevice: false,
+  })
   const [invitor, invitee] = managers
   const disconnectPeers = connectPeers(managers)
   t.after(disconnectPeers)


### PR DESCRIPTION
Fixes https://github.com/digidem/comapeo-mobile/issues/1539

We weren't actually checking if the blocks for attachments were downloaded, just if entries were present. Entries were present even if the download never happened