### PR TITLE
feat: Allow last coordinators to leave projects

### DIFF
--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -22,7 +22,7 @@ import {
   waitForSync,
 } from './utils.js'
 
-test("Creator cannot leave project if they're the only coordinator", async (t) => {
+test("Creator can leave project if they're the only coordinator", async (t) => {
   const managers = await createManagers(2, t)
 
   const disconnectPeers = connectPeers(managers)
@@ -54,9 +54,13 @@ test("Creator cannot leave project if they're the only coordinator", async (t) =
     'creator successfully added from member perspective'
   )
 
-  await assert.rejects(async () => {
-    await creator.leaveProject(projectId)
-  }, 'creator attempting to leave project with no other coordinators fails')
+  await creator.leaveProject(projectId)
+
+  assert.equal(
+    (await creatorProject.$getOwnRole()).roleId,
+    LEFT_ROLE_ID,
+    'creator now has LEFT role'
+  )
 })
 
 test('leaving a project as the only member', async (t) => {


### PR DESCRIPTION
Front end wants control over when we should block leaves. Fixes #1134 