### PR TITLE
chore: fix remote server test for duplicate server add issue

### DIFF
--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -420,10 +420,7 @@ export class DataType extends TypedEmitter {
     )
     const { docId, createdAt, originalVersionId } = prevDocs[0]
     const areLinksValid = prevDocs.every(
-      (doc) =>
-        doc.docId === docId &&
-        doc.schemaName === this.#schemaName &&
-        doc.originalVersionId === originalVersionId
+      (doc) => doc.docId === docId && doc.schemaName === this.#schemaName
     )
     if (!areLinksValid) {
       throw new Error('Updated docs must have the same docId and schemaName')


### PR DESCRIPTION
For https://github.com/digidem/comapeo-core/pull/1200 I skipped running the new failing test on a remote server because the test setup was failing. The underlying issue is that there is a different race condition bug in the server when two clients try to add the same project to the server at the same time, which is low-priority to fix and I'm tracking in this issue: https://github.com/digidem/comapeo-cloud/issues/66

This PR updates the test to add the duplicate server to the project sequentially. The underlying issue was not adding a duplicate server at exactly the same time, but two devices adding the same server while not connected / syncing with each other, so this updated test should catch the issue.

Although this PR only updates the test, I have reverted the fix, then added the [test as a separate commit](https://github.com/digidem/comapeo-core/pull/1201/commits/d5552a63bb2f960182e13cb8a9d999345e6dbbaa), to verify that the test actually fails prior to the fix still.

I recommend reviewing with the "Hide whitespace" option in Github, to help focus on the lines that have changed.