### PR TITLE
fix: pin drizzle-orm to exact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "debug": "^4.3.4",
         "dot-prop": "^9.0.0",
         "dot-prop-extra": "^10.2.0",
-        "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+        "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
         "ensure-error": "^4.0.0",
         "fastify": "^4.0.0",
         "fastify-plugin": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "debug": "^4.3.4",
     "dot-prop": "^9.0.0",
     "dot-prop-extra": "^10.2.0",
-    "drizzle-orm": "^1.0.0-beta.1-ac4ce44",
+    "drizzle-orm": "1.0.0-beta.1-fd8bfcc",
     "ensure-error": "^4.0.0",
     "fastify": "^4.0.0",
     "fastify-plugin": "^4.5.1",


### PR DESCRIPTION
Closes #1204 

Pins it to the version that's currently being used based on the existing lockfile, which I believe is the latest release on their beta-1 track.