### PR TITLE
fix: Allow for floating point errors in map bounds

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,10 @@ import { omit } from './lib/omit.js'
 
 const PROJECT_INVITE_ID_SALT = Buffer.from('mapeo project invite id', 'ascii')
 
-export const MAX_BOUNDS = [-180, -85.051129, 180, 85.051129]
+// Slightly larger than spherical mercator bounds for a square map - rounds up
+// from 85.051129 to allow for floating point errors in the bounds of some maps
+// in userspace.
+export const MAX_BOUNDS = [-180, -85.05113, 180, 85.05113]
 
 /**
  *


### PR DESCRIPTION
Some maps in userspace have bounds that are outside the spherical mercator bounds, but are still valid. This seems to be due to floating point errors creeping in, for example this map from the maplibre website:

```json
{
 "sources": {
    "maplibre": {
      "type": "vector",
      "bounds": [-180, -85.051129, 180, 85.05112900000002],
```

This should fix things for this map, but we should keep an eye on these errors in case we want to just remove this check if there are lots of maps "in the wild" with invalid bounds. Perhaps this is something that styled-map-package can sanitize/fix when creating the file.