### PR TITLE
chore: remove file extension from the errors export

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "types": "./dist/index.d.ts",
       "import": "./src/index.js"
     },
-    "./errors.js": {
+    "./errors": {
       "types": "./dist/errors.d.ts",
       "import": "./src/errors.js"
     }


### PR DESCRIPTION
Should be a bit cleaner and more standard

e.g.

```javascript
import { SomeError } from `@comapeo/core/errors`
```

instead of

```javascript
import { SomeError } from `@comapeo/core/errors.js`
```