### PR TITLE
feat: Detect if peer supports map share RPC

### DIFF
--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -46,6 +46,7 @@ message DeviceInfo {
   enum RPCFeatures {
     features_unspecified = 0;
     ack = 1;
+    map_share = 2;
   }
   string name = 1;
   optional DeviceType deviceType = 2;

--- a/src/errors.js
+++ b/src/errors.js
@@ -42,6 +42,12 @@ export const RPCDisconnectBeforeAckError = createErrorClass({
   status: 499,
 })
 
+export const MapShareNotSupportedByPeerError = createErrorClass({
+  code: 'MAP_SHARE_NOT_SUPPORTED_BY_PEER',
+  message: 'This peer does not support map share requests',
+  status: 405,
+})
+
 export const TimeoutError = createErrorClass({
   code: 'TIMEOUT_ERROR',
   message: 'Operation timed out',

--- a/src/generated/rpc.d.ts
+++ b/src/generated/rpc.d.ts
@@ -52,6 +52,7 @@ export declare function deviceInfo_DeviceTypeToNumber(object: DeviceInfo_DeviceT
 export declare const DeviceInfo_RPCFeatures: {
     readonly features_unspecified: "features_unspecified";
     readonly ack: "ack";
+    readonly map_share: "map_share";
     readonly UNRECOGNIZED: "UNRECOGNIZED";
 };
 export type DeviceInfo_RPCFeatures = typeof DeviceInfo_RPCFeatures[keyof typeof DeviceInfo_RPCFeatures];

--- a/src/generated/rpc.js
+++ b/src/generated/rpc.js
@@ -89,6 +89,7 @@ export function deviceInfo_DeviceTypeToNumber(object) {
 export var DeviceInfo_RPCFeatures = {
     features_unspecified: "features_unspecified",
     ack: "ack",
+    map_share: "map_share",
     UNRECOGNIZED: "UNRECOGNIZED",
 };
 export function deviceInfo_RPCFeaturesFromJSON(object) {
@@ -99,6 +100,9 @@ export function deviceInfo_RPCFeaturesFromJSON(object) {
         case 1:
         case "ack":
             return DeviceInfo_RPCFeatures.ack;
+        case 2:
+        case "map_share":
+            return DeviceInfo_RPCFeatures.map_share;
         case -1:
         case "UNRECOGNIZED":
         default:
@@ -111,6 +115,8 @@ export function deviceInfo_RPCFeaturesToNumber(object) {
             return 0;
         case DeviceInfo_RPCFeatures.ack:
             return 1;
+        case DeviceInfo_RPCFeatures.map_share:
+            return 2;
         case DeviceInfo_RPCFeatures.UNRECOGNIZED:
         default:
             return -1;

--- a/src/generated/rpc.ts
+++ b/src/generated/rpc.ts
@@ -134,6 +134,7 @@ export function deviceInfo_DeviceTypeToNumber(object: DeviceInfo_DeviceType): nu
 export const DeviceInfo_RPCFeatures = {
   features_unspecified: "features_unspecified",
   ack: "ack",
+  map_share: "map_share",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -147,6 +148,9 @@ export function deviceInfo_RPCFeaturesFromJSON(object: any): DeviceInfo_RPCFeatu
     case 1:
     case "ack":
       return DeviceInfo_RPCFeatures.ack;
+    case 2:
+    case "map_share":
+      return DeviceInfo_RPCFeatures.map_share;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -160,6 +164,8 @@ export function deviceInfo_RPCFeaturesToNumber(object: DeviceInfo_RPCFeatures): 
       return 0;
     case DeviceInfo_RPCFeatures.ack:
       return 1;
+    case DeviceInfo_RPCFeatures.map_share:
+      return 2;
     case DeviceInfo_RPCFeatures.UNRECOGNIZED:
     default:
       return -1;

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -77,16 +77,17 @@ const MESSAGES_MAX_ID = Math.max.apply(null, [...Object.values(MESSAGE_TYPES)])
 
 export const kTestOnlySendRawInvite = Symbol('testOnlySendRawInvite')
 
-export const PEER_FEATURE_MAP_SHARE = 'map_share'
-
-/** @typedef {typeof PEER_FEATURE_MAP_SHARE} PeerFeature*/
+/**
+ * @typedef {object} PeerSupportedFeatures
+ * @property {boolean} mapShare True when this peer supports receiving Map Share requests
+ */
 
 /**
  * @typedef {object} PeerInfoBase
  * @property {string} deviceId
  * @property {string | undefined} name
  * @property {import('./generated/rpc.js').DeviceInfo['deviceType']} deviceType
- * @property {PeerFeature[]} supportedFeatures
+ * @property {PeerSupportedFeatures} supportedFeatures
  */
 /** @typedef {PeerInfoBase & { status: 'connecting' }} PeerInfoConnecting */
 /** @typedef {PeerInfoBase & { status: 'connected', connectedAt: number, protomux: Protomux<import('@hyperswarm/secret-stream')> }} PeerInfoConnected */
@@ -144,10 +145,9 @@ class Peer {
 
   /** @returns {PeerInfoInternal} */
   get info() {
-    /** @type {PeerFeature[]} */
-    const supportedFeatures = []
-    if (this.supportsMapShare()) {
-      supportedFeatures.push(PEER_FEATURE_MAP_SHARE)
+    /** @type {PeerSupportedFeatures} */
+    const supportedFeatures = {
+      mapShare: this.supportsMapShare(),
     }
     switch (this.#state) {
       case 'connecting':

--- a/src/local-peers.js
+++ b/src/local-peers.js
@@ -28,6 +28,7 @@ import {
   ExhaustivenessError,
   InvalidInviteError,
   InvalidProjectJoinDetailsError,
+  MapShareNotSupportedByPeerError,
 } from './errors.js'
 /** @import NoiseStream from '@hyperswarm/secret-stream' */
 /** @import { OpenedNoiseStream } from './lib/noise-secret-stream-helpers.js' */
@@ -76,11 +77,16 @@ const MESSAGES_MAX_ID = Math.max.apply(null, [...Object.values(MESSAGE_TYPES)])
 
 export const kTestOnlySendRawInvite = Symbol('testOnlySendRawInvite')
 
+export const PEER_FEATURE_MAP_SHARE = 'map_share'
+
+/** @typedef {typeof PEER_FEATURE_MAP_SHARE} PeerFeature*/
+
 /**
  * @typedef {object} PeerInfoBase
  * @property {string} deviceId
  * @property {string | undefined} name
  * @property {import('./generated/rpc.js').DeviceInfo['deviceType']} deviceType
+ * @property {PeerFeature[]} supportedFeatures
  */
 /** @typedef {PeerInfoBase & { status: 'connecting' }} PeerInfoConnecting */
 /** @typedef {PeerInfoBase & { status: 'connected', connectedAt: number, protomux: Protomux<import('@hyperswarm/secret-stream')> }} PeerInfoConnected */
@@ -135,8 +141,14 @@ class Peer {
       return log.apply(null, [`[%S] ${formatter}`, peerId, ...args])
     }
   }
+
   /** @returns {PeerInfoInternal} */
   get info() {
+    /** @type {PeerFeature[]} */
+    const supportedFeatures = []
+    if (this.supportsMapShare()) {
+      supportedFeatures.push(PEER_FEATURE_MAP_SHARE)
+    }
     switch (this.#state) {
       case 'connecting':
         return {
@@ -144,6 +156,7 @@ class Peer {
           deviceId: this.#deviceId,
           name: this.#name,
           deviceType: this.#deviceType,
+          supportedFeatures,
         }
       case 'connected':
         return {
@@ -153,6 +166,7 @@ class Peer {
           deviceType: this.#deviceType,
           connectedAt: this.#connectedAt,
           protomux: this.#protomux,
+          supportedFeatures,
         }
       case 'disconnected':
         return {
@@ -161,6 +175,7 @@ class Peer {
           name: this.#name,
           deviceType: this.#deviceType,
           disconnectedAt: this.#disconnectedAt,
+          supportedFeatures,
         }
       /* c8 ignore next 2 */
       default:
@@ -241,6 +256,14 @@ class Peer {
    */
   supportsAck() {
     return this.#features.includes(DeviceInfo_RPCFeatures.ack) ?? false
+  }
+
+  /**
+   * Check if Map Share messages are supported by this peer
+   * @returns {boolean}
+   */
+  supportsMapShare() {
+    return this.#features.includes(DeviceInfo_RPCFeatures.map_share) ?? false
   }
 
   /**
@@ -492,6 +515,9 @@ export class LocalPeers extends TypedEmitter {
   async sendMapShare(deviceId, mapShare) {
     await this.#waitForPendingConnections()
     const peer = await this.#getPeerByDeviceId(deviceId)
+    if (!peer.supportsMapShare()) {
+      throw new MapShareNotSupportedByPeerError()
+    }
     await peer.sendMapShare(mapShare)
   }
 

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -119,6 +119,10 @@ export const DEFAULT_ONLINE_STYLE_URL =
   'https://demotiles.maplibre.org/style.json'
 
 export const DEFAULT_IS_ARCHIVE_DEVICE = true
+const RPC_FEATURES = [
+  DeviceInfo_RPCFeatures.ack,
+  DeviceInfo_RPCFeatures.map_share,
+]
 
 /**
  * @typedef {Omit<import('./local-peers.js').PeerInfo, 'protomux'>} PublicPeerInfo
@@ -339,7 +343,7 @@ export class MapeoManager extends TypedEmitter {
 
         const deviceInfoToSend = {
           ...deviceInfo,
-          features: [DeviceInfo_RPCFeatures.ack],
+          features: RPC_FEATURES,
         }
 
         const peerId = keyToId(openedNoiseStream.remotePublicKey)
@@ -863,7 +867,7 @@ export class MapeoManager extends TypedEmitter {
       const deviceInfoToSend = {
         ...deviceInfo,
         deviceType,
-        features: [DeviceInfo_RPCFeatures.ack],
+        features: RPC_FEATURES,
       }
       await Promise.all(
         this.#localPeers.peers

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -31,6 +31,7 @@ import { execa } from 'execa'
 import { ExhaustivenessError } from '../src/errors.js'
 
 /** @import { InvitePeerInfo, MemberApi } from '../src/member-api.js' */
+/** @import { PublicPeerInfo } from '../src/mapeo-manager.js' */
 
 const projectMigrationsFolder = new URL('../drizzle/project', import.meta.url)
   .pathname
@@ -167,9 +168,10 @@ async function pEvery(iterable, predicate) {
 
 /**
  * @internal
- * @typedef {Pick<MapeoManager, 'deviceId' | 'listLocalPeers'> & {
+ * @typedef {Pick<MapeoManager, 'deviceId'> & {
  *    on(event: 'local-peers', listener: () => unknown): void;
  *    off(event: 'local-peers', listener: () => unknown): void;
+ *    listLocalPeers(): Promise<Pick<PublicPeerInfo, 'deviceId' | 'deviceType' | 'name' | 'status'>[]>
  * }} WaitForPeersManager
  */
 


### PR DESCRIPTION
This is needed so that frontend can avoid sending map share requests to peers that don't support it and causing the server to wait indefinitely for a timeout.

- New `supportedFeatures` flags in local peers info
- New flag in RPC to denote map share RPC support in DeviceInfo
- Fixes for cross version tests