### PR TITLE
fix: remove dangling setTimeout in waitForSync

### DIFF
--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -460,12 +460,13 @@ export class SyncApi extends TypedEmitter {
       /** @param {import('./sync-state.js').State} state */
       const onState = (state) => {
         clearTimeout(timeoutId)
-        if (typeof timeoutMs === 'number') {
-          timeoutId = setTimeout(onTimeout, timeoutMs)
-        }
         if (isSynced(state, type, this.#peerSyncControllers)) {
           this[kSyncState].off('state', onState)
           resolve()
+          return
+        }
+        if (typeof timeoutMs === 'number') {
+          timeoutId = setTimeout(onTimeout, timeoutMs)
         }
       }
       this[kSyncState].on('state', onState)


### PR DESCRIPTION
Fixes #1265

Reorder `onState` to check `isSynced` first and return early; only arm the timer when we still need to wait.