### PR TITLE
fix: stop sync once a member is removed

### DIFF
--- a/src/datatype/index.js
+++ b/src/datatype/index.js
@@ -245,6 +245,14 @@ export class DataType extends TypedEmitter {
    * @returns {Promise<TDoc & DerivedDocFields>}
    */
   /**
+   * @overload
+   * @param {string} docId
+   * @param {object} [options]
+   * @param {false} options.mustBeFound
+   * @param {string} [options.lang]
+   * @returns {Promise<null | (TDoc & DerivedDocFields)>}
+   */
+  /**
    * @param {string} docId
    * @param {object} [options]
    * @param {boolean} [options.mustBeFound]

--- a/src/sync/peer-sync-controller.js
+++ b/src/sync/peer-sync-controller.js
@@ -1,7 +1,7 @@
 import mapObject from 'map-obj'
 import { NAMESPACES, PRESYNC_NAMESPACES } from '../constants.js'
 import { Logger } from '../logger.js'
-import { createMap } from '../utils.js'
+import { createMap, noop } from '../utils.js'
 import { unreplicate } from '../lib/hypercore-helpers.js'
 import { ExhaustivenessError } from '../errors.js'
 /** @import { CoreRecord } from '../core-manager/index.js' */
@@ -21,6 +21,7 @@ export class PeerSyncController {
   #coreManager
   #protomux
   #roles
+  #syncState
   /** @type {Record<Namespace, SyncCapability>} */
   #syncCapability = createNamespaceMap('unknown')
   /** @type {SyncEnabledState} */
@@ -52,14 +53,22 @@ export class PeerSyncController {
     this.#coreManager = coreManager
     this.#protomux = protomux
     this.#roles = roles
+    this.#syncState = syncState
 
     // Always need to replicate the project creator core
     this.#replicateCoreRecord(coreManager.creatorCoreRecord)
 
     coreManager.on('add-core', this.#handleAddCore)
     syncState.on('state', this.#handleStateChange)
+    roles.on('update', this.#handleRolesUpdate)
 
     this.#updateEnabledNamespaces()
+  }
+
+  dispose() {
+    this.#coreManager.off('add-core', this.#handleAddCore)
+    this.#syncState.off('state', this.#handleStateChange)
+    this.#roles.off('update', this.#handleRolesUpdate)
   }
 
   get peerKey() {
@@ -154,19 +163,62 @@ export class PeerSyncController {
     this.#prevSyncStatus = this.#syncStatus
 
     if (didUpdate.auth) {
-      try {
-        this.#log('reading role for %h', this.peerId)
-        const cap = await this.#roles.getRole(this.peerId)
-        this.#syncCapability = cap.sync
-      } catch (e) {
-        this.#log('Error reading role', e)
-        // Any error, consider sync unknown
-        this.#syncCapability = createNamespaceMap('unknown')
-      }
+      await this.#readAndCacheSyncCapability()
     }
     this.#log('capability %o', this.#syncCapability)
 
     this.#updateEnabledNamespaces()
+  }
+
+  /**
+   * Refresh capability when a role doc affecting this peer is indexed.
+   *
+   * `#handleStateChange` covers the receive-side case (auth namespace
+   * transitions not-synced → synced when the role doc arrives), but on
+   * the writer's side `auth.want` stays at 0 throughout a self-written
+   * role doc, so that transition never fires. This listener fills that
+   * gap. Receive-side updates will harmlessly re-refresh.
+   *
+   * @param {Set<string>} roleDocIds
+   */
+  #handleRolesUpdate = (roleDocIds) => {
+    if (!this.peerId) return
+    if (!roleDocIds.has(this.peerId)) return
+    this.#refreshSyncCapability().catch(noop)
+  }
+
+  /**
+   * Re-read this peer's role and update {@link #syncCapability}.
+   *
+   * Preserve auth capability as a workaround for the BLOCKED role currently
+   * disallowing sync of auth - with this fix it would mean that a blocked user
+   * never learns that they have been blocked (because their auth core never
+   * syncs). Once we update the BLOCKED role defaults, we can remove the
+   * preservation of auth capability.
+   *
+   * @returns {Promise<void>}
+   */
+  async #refreshSyncCapability() {
+    const prevAuth = this.#syncCapability.auth
+    await this.#readAndCacheSyncCapability()
+    this.#syncCapability.auth = prevAuth
+    this.#updateEnabledNamespaces()
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async #readAndCacheSyncCapability() {
+    try {
+      this.#log('reading role for %h', this.peerId)
+      const cap = await this.#roles.getRole(this.peerId)
+      // Copy: ROLES.*.sync is a shared object reference.
+      this.#syncCapability = { ...cap.sync }
+    } catch (e) {
+      this.#log('Error reading role', e)
+      // Any error, consider sync unknown
+      this.#syncCapability = createNamespaceMap('unknown')
+    }
   }
 
   /**

--- a/src/sync/sync-api.js
+++ b/src/sync/sync-api.js
@@ -568,13 +568,15 @@ export class SyncApi extends TypedEmitter {
    */
   #handlePeerDisconnect = (peer) => {
     const { protomux } = peer
-    if (!this.#peerSyncControllers.has(protomux)) {
+    const psc = this.#peerSyncControllers.get(protomux)
+    if (!psc) {
       this.#l.log(
         'Unexpected no existing peer sync controller for peer %h',
         protomux.stream.remotePublicKey
       )
       return
     }
+    psc.dispose()
     this.#peerSyncControllers.delete(protomux)
     const peerId = keyToId(peer.remotePublicKey)
     this.#pscByPeerId.delete(peerId)

--- a/test-e2e/role-update-sync-capability.js
+++ b/test-e2e/role-update-sync-capability.js
@@ -1,0 +1,96 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { generate } from '@mapeo/mock-data'
+import { valueOf } from '../src/utils.js'
+import { BLOCKED_ROLE_ID } from '../src/roles.js'
+import { connectPeers, createManagers, invite, waitForSync } from './utils.js'
+
+// Regression test for mid-session role downgrades.
+//
+// When a coordinator changes a peer's role to BLOCKED while that peer's
+// protomux session is still alive, the coordinator's PeerSyncController
+// for that peer must refresh its cached sync capability. Today it does
+// not:
+//
+// - PSC#updatePeerState only refreshes capability when the auth namespace
+//   transitions not-synced → synced.
+// - On the coordinator side, after writing a role doc themselves, their
+//   own auth.localState.want stays at 0 throughout, so syncStatus[auth]
+//   never leaves 'synced' and the transition never fires.
+// - SyncApi#handleRoleUpdate IS called on role doc changes (via the
+//   roles.on('update') wiring), but only ever calls
+//   #validateRoleAndAddCoresForPeer — never refreshes capability on
+//   existing PSCs.
+//
+// Result: role downgrades keep replicating to the now-blocked peer until
+// the protomux session ends — a data leak.
+test('role downgrade (member → blocked) stops replication on the same session', async (t) => {
+  const [invitor, invitee] = await createManagers(2, t)
+  const disconnect = connectPeers([invitor, invitee])
+  t.after(disconnect)
+
+  const projectId = await invitor.createProject({ name: 'block-mid-session' })
+  await invite({ invitor, invitees: [invitee], projectId })
+  const invitorProject = await invitor.getProject(projectId)
+  const inviteeProject = await invitee.getProject(projectId)
+
+  // Get to a steady state with real data, both peers actively syncing.
+  const initialDocs = generate('observation', { count: 20 })
+  for (const o of initialDocs) {
+    await invitorProject.observation.create(valueOf(o))
+  }
+  invitorProject.$sync.start()
+  inviteeProject.$sync.start()
+  await waitForSync([invitorProject, inviteeProject], 'full', {
+    timeout: 30_000,
+  })
+
+  // Sanity: invitor sees invitee as data-enabled before the block.
+  {
+    const inviteeView =
+      invitorProject.$sync.getState().remoteDeviceSyncState[invitee.deviceId]
+    assert(
+      inviteeView?.data.isSyncEnabled,
+      'invitor sees invitee data-enabled pre-block'
+    )
+  }
+
+  await invitorProject.$member.assignRole(invitee.deviceId, BLOCKED_ROLE_ID)
+
+  // The sync state on the invitor must reflect the capability change
+  // without waiting for a protomux session cycle.
+  await new Promise((res, rej) => {
+    const timer = setTimeout(() => {
+      invitorProject.$sync.off('sync-state', onState)
+      rej(new Error('data sync was not disabled within 30s of block'))
+    }, 30_000)
+    /**
+     * @param {import('../src/sync/sync-api.js').State} state
+     */
+    const onState = ({ remoteDeviceSyncState }) => {
+      if (!remoteDeviceSyncState[invitee.deviceId]?.data.isSyncEnabled) {
+        clearTimeout(timer)
+        invitorProject.$sync.off('sync-state', onState)
+        res(void 0)
+      }
+    }
+    invitorProject.$sync.on('sync-state', onState)
+    onState(invitorProject.$sync.getState())
+  })
+
+  // Behavioural assertion: docs created after the block must not reach
+  // the blocked peer.
+  const postBlockDoc = await invitorProject.observation.create(
+    valueOf(generate('observation')[0])
+  )
+  await new Promise((r) => setTimeout(r, 2_000))
+  const inviteeHas = await inviteeProject.observation.getByDocId(
+    postBlockDoc.docId,
+    { mustBeFound: false }
+  )
+  assert.equal(
+    inviteeHas,
+    null,
+    'blocked invitee did not receive doc created after block'
+  )
+})


### PR DESCRIPTION
When a coordinator downgrades a peer's role by calling `$member.assignRole(deviceId, BLOCKED_ROLE_ID)` or `$member.remove(deviceId)` while the peer is still connected, the coordinator continues replicating user data to that peer until the peer's protomux session ends. New observations, blobs, and other data flow to a peer that has just been blocked, for the lifetime of the connection.

Root cause: `PSC#handleStateChange` only refreshes capability on an auth-namespace `not-synced → synced` transition. The writer's own `auth.want` stays at 0 throughout a self-written role doc, so that transition never fires.

**Changes**
- `PeerSyncController` subscribes directly to `roles.on('update', …)`, filtered by `this.peerId`. The event fires after the indexer has finished processing newly-indexed role docs, so the subsequent `getRole` read is guaranteed fresh.
- A new `#refreshSyncCapability` path preserves the **auth** capability only — config, blobIndex, data, and blob all cut off immediately on a downgrade. The auth-preservation works around `BLOCKED_ROLE.sync.auth = 'blocked'`: without it, a blocked peer's auth core would stop syncing on the writer's side and they'd never receive the role doc telling them they're blocked. Follow-up: revisit the BLOCKED role defaults so this preservation can be removed.
- `PeerSyncController.dispose()` removes its `coreManager`/`syncState`/`roles` listeners; called from `SyncApi#handlePeerDisconnect`. Also closes a pre-existing minor listener leak on `coreManager` per reconnect.
- Existing `#handleStateChange` auth-refresh path is retained — it still covers the implicit project-creator role inferred from `coreOwnership`, where no role doc exists in the indexer to fire an update event (matters during initial sync).

The first commit here is a regression test confirming the issue.