### PR TITLE
fix: don't reject leaveProject when post-leave sync propagation stalls

### DIFF
--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -1050,10 +1050,18 @@ export class MapeoManager extends TypedEmitter {
 
     await project[kProjectLeave]()
 
-    // Sync any role changes from project leave
-    await project.$sync.waitForSync('initial', {
-      timeoutMs: INITIAL_SYNC_TIMEOUT_MS,
-    })
+    // Failure to sync the leave action (e.g. due to poor connectivity with a
+    // peer) should not throw this `leaveProject()` action, because an API
+    // consumer reads the error as a failure to leave, but leave has already
+    // happened. This is a "best effort" attempt to sync the leave state. If it
+    // fails, it will sync on the next connection.
+    try {
+      await project.$sync.waitForSync('initial', {
+        timeoutMs: INITIAL_SYNC_TIMEOUT_MS,
+      })
+    } catch {
+      // Ignore — propagation is opportunistic.
+    }
   }
 
   /**

--- a/test-e2e/controllable-wire.js
+++ b/test-e2e/controllable-wire.js
@@ -1,0 +1,111 @@
+import { Transform } from 'node:stream'
+import { kProjectReplicate } from '../src/mapeo-project.js'
+
+/** @import { MapeoProject } from '../src/mapeo-project.js' */
+
+/**
+ * A `Transform` that forwards bytes unchanged, but can inject latency and be
+ * paused/resumed. Because a Transform processes one chunk at a time (the next
+ * `_transform` only runs after the previous `cb`), holding `cb` while paused
+ * applies real backpressure and preserves chunk order on resume.
+ *
+ * @param {{ latencyMs?: number }} [opts]
+ */
+function makeGate({ latencyMs = 0 } = {}) {
+  let paused = false
+  /** @type {Array<() => void>} */
+  const held = []
+  const gate = new Transform({
+    transform(chunk, _encoding, cb) {
+      const release = () => cb(null, chunk)
+      const go = () => (latencyMs ? setTimeout(release, latencyMs) : release())
+      if (paused) held.push(go)
+      else go()
+    },
+  })
+  return Object.assign(gate, {
+    pauseFlow() {
+      paused = true
+    },
+    resumeFlow() {
+      paused = false
+      while (held.length) {
+        const go = held.shift()
+        if (go) go()
+      }
+    },
+  })
+}
+
+/**
+ * Connect two real projects over a transport we fully control — models the
+ * network (latency, pause/resume, abrupt teardown) without touching any sync
+ * internals. Uses the same `kProjectReplicate` replication seam the server path
+ * uses, so each side replicates under its real device identity
+ * (`peerId === deviceId`).
+ *
+ * Returns one "link"; call it twice for the same pair to create two concurrent
+ * connections for one identity (the D1 overlap that local discovery dedups).
+ *
+ * @param {MapeoProject} projectA
+ * @param {MapeoProject} projectB
+ * @param {{ latencyMs?: number }} [opts]
+ */
+export function connectProjectsControllably(projectA, projectB, opts = {}) {
+  const streamA = projectA[kProjectReplicate](true)
+  const streamB = projectB[kProjectReplicate](false)
+  const gateAtoB = makeGate(opts)
+  const gateBtoA = makeGate(opts)
+
+  // Swallow errors caused by destroying mid-flight (REQUEST_CANCELLED etc. on
+  // the transport itself; the point of the tests is what the *app* surfaces).
+  for (const stream of [streamA, streamB, gateAtoB, gateBtoA]) {
+    stream.on('error', () => {})
+  }
+
+  // The replication streams are streamx Duplexes; piping them through Node
+  // Transforms works at runtime (same approach as wsCoreReplicator) but the
+  // type shapes differ, so cast for the pipe wiring.
+  const a = /** @type {import('node:stream').Duplex} */ (
+    /** @type {unknown} */ (streamA)
+  )
+  const b = /** @type {import('node:stream').Duplex} */ (
+    /** @type {unknown} */ (streamB)
+  )
+  a.pipe(gateAtoB).pipe(b)
+  b.pipe(gateBtoA).pipe(a)
+
+  let destroyed = false
+
+  return {
+    /** Hold all bytes in both directions until {@link resume}. */
+    pause() {
+      gateAtoB.pauseFlow()
+      gateBtoA.pauseFlow()
+    },
+    /** Hold only A→B bytes (e.g. starve one peer of a specific update). */
+    pauseAtoB() {
+      gateAtoB.pauseFlow()
+    },
+    resume() {
+      gateAtoB.resumeFlow()
+      gateBtoA.resumeFlow()
+    },
+    /** Abruptly drop the connection (like a yanked cable). */
+    async destroy() {
+      if (destroyed) return
+      destroyed = true
+      streamA.destroy()
+      streamB.destroy()
+      await Promise.all(
+        [streamA, streamB].map(
+          (stream) =>
+            new Promise((res) => {
+              if (stream.destroyed) return res(undefined)
+              stream.once('close', () => res(undefined))
+            })
+        )
+      )
+    },
+  }
+}

--- a/test-e2e/sync-leave-regression.js
+++ b/test-e2e/sync-leave-regression.js
@@ -1,0 +1,76 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { LEFT_ROLE_ID, MEMBER_ROLE_ID } from '../src/roles.js'
+import { connectPeers, createManagers, invite, waitForSync } from './utils.js'
+import { connectProjectsControllably } from './controllable-wire.js'
+
+// Regression test for the intermittent "Sync timeout" error users hit when
+// leaving a project.
+//
+// `manager.leaveProject` performs the local leave (assign LEFT + kClearData)
+// and then makes a best-effort attempt to propagate the LEFT role to connected
+// peers via `waitForSync('initial', { timeoutMs })`. That propagation must NOT
+// reject the leave if it stalls — the device has already left locally. Before
+// the fix the trailing wait was awaited unconditionally, so a connected-but-
+// slow/flaky peer (or the user moving out of range as they leave) made
+// leaveProject reject with Error('Sync timeout').
+//
+// We reproduce a stalled-but-connected peer deterministically by driving the
+// connection over a transport we control (test-e2e/controllable-wire.js) and
+// pausing it at the moment of leaving. This takes ~45s (the internal
+// INITIAL_SYNC_TIMEOUT_MS) because the fix lets the propagation time out and
+// then swallows it.
+test(
+  'leaveProject does not reject when post-leave sync propagation stalls',
+  { timeout: 90_000 },
+  async (t) => {
+    const [ma, mb] = await createManagers(2, t)
+
+    // Establish membership over local discovery, then drive the sync phase over
+    // a transport we control so we can stall it at the moment of leaving.
+    const disconnectInvite = connectPeers([ma, mb])
+    const projectId = await ma.createProject({ name: 'leave-stall' })
+    await invite({
+      invitor: ma,
+      invitees: [mb],
+      projectId,
+      roleId: MEMBER_ROLE_ID,
+    })
+    await disconnectInvite()
+
+    const creatorProject = await ma.getProject(projectId)
+    const memberProject = await mb.getProject(projectId)
+
+    const link = connectProjectsControllably(creatorProject, memberProject)
+    t.after(() => link.destroy())
+
+    creatorProject.$sync.start()
+    memberProject.$sync.start()
+    await waitForSync([creatorProject, memberProject], 'initial')
+
+    // The connection degrades exactly as the member leaves: the peer is still
+    // "connected" (the PSC stays), but no bytes flow — a common mobile scenario.
+    link.pause()
+
+    /** @type {unknown} */
+    let leaveError = null
+    await mb.leaveProject(projectId).catch((err) => {
+      leaveError = err
+    })
+
+    // The local leave succeeded regardless — the device IS left...
+    assert.equal(
+      (await memberProject.$getOwnRole()).roleId,
+      LEFT_ROLE_ID,
+      'the device has locally left (LEFT role assigned, data cleared)'
+    )
+    // ...so a transient propagation stall must not surface as a thrown error.
+    assert.equal(
+      leaveError,
+      null,
+      `leaveProject rejected on a stalled best-effort propagation: ${
+        leaveError instanceof Error ? leaveError.message : String(leaveError)
+      }`
+    )
+  }
+)


### PR DESCRIPTION
leaveProject performs the local leave (assign LEFT + clear data) and then awaits a trailing waitForSync('initial', { timeoutMs: 45s }) to propagate the LEFT role to connected peers. That wait was awaited unconditionally, so when a peer is connected but presync can't complete within 45s — a slow/flaky link, or the user moving out of range right as they leave — leaveProject rejected with Error('Sync timeout') even though the device had already left locally. This is the intermittent "Sync timeout" error users have hit leaving projects.

Make the propagation best-effort: the local leave has already succeeded and the LEFT role (persisted to the auth namespace) also propagates on the next connection, so a stalled propagation must not fail the operation.

Adds a regression test (test-e2e/sync-leave-regression.js) plus a controllable transport test helper (test-e2e/controllable-wire.js) that drives two real projects over a pause-able wire to deterministically reproduce a connected-but- stalled peer.