### PR TITLE
fix: remove DataStore add-core listener on close()

### DIFF
--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -50,6 +50,8 @@ export class DataStore extends TypedEmitter {
   #pendingAppends = new Set()
   /** @type {Record<MapeoDoc['schemaName'], Set<string>>} */
   #pendingEmits
+  /** @type {(coreRecord: import('../core-manager/index.js').CoreRecord) => void} */
+  #handleAddCore
 
   /**
    * @param {object} opts
@@ -75,10 +77,11 @@ export class DataStore extends TypedEmitter {
       batch: (entries) => this.#handleEntries(entries),
       reindex,
     })
-    coreManager.on('add-core', (coreRecord) => {
+    this.#handleAddCore = (coreRecord) => {
       if (coreRecord.namespace !== namespace) return
       this.#coreIndexer.addCore(coreRecord.core)
-    })
+    }
+    coreManager.on('add-core', this.#handleAddCore)
     this.#coreIndexer.on('idle', this.#handleIndexerIdle)
   }
 
@@ -214,6 +217,10 @@ export class DataStore extends TypedEmitter {
   }
 
   async close() {
+    // Remove the add-core listener before closing the indexer so a late
+    // 'add-core' event during teardown can't call addCore() on a closed indexer
+    // (which would throw 'Cannot add core after closing').
+    this.#coreManager.off('add-core', this.#handleAddCore)
     await this.#coreIndexer.close()
   }
 

--- a/test/datastore.js
+++ b/test/datastore.js
@@ -69,6 +69,29 @@ test('read and write', async (t) => {
   )
 })
 
+test('close() removes its add-core listener from the coreManager', async (t) => {
+  const cm = createCoreManager(t)
+  const before = cm.listenerCount('add-core')
+  const dataStore = new DataStore({
+    coreManager: cm,
+    namespace: 'data',
+    batch: async () => ({}),
+    storage: () => new RAM(),
+    reindex: false,
+  })
+  assert.equal(
+    cm.listenerCount('add-core'),
+    before + 1,
+    'DataStore registers one add-core listener'
+  )
+  await dataStore.close()
+  assert.equal(
+    cm.listenerCount('add-core'),
+    before,
+    'close() removes the add-core listener so a late add-core during teardown cannot call addCore() on a closed indexer'
+  )
+})
+
 test('writeRaw and read', async (t) => {
   const cm = createCoreManager(t)
   const writerCore = cm.getWriterCore('config').core


### PR DESCRIPTION
Fixes #1277.

`DataStore` registered a permanent `add-core` listener on the `CoreManager` but never removed it on `close()`. If `coreManager` emitted `add-core` after the `DataStore`'s `MultiCoreIndexer` had closed (a teardown racing with a sync session or peer connection adding a core), the listener called `addCore()` on a closed indexer, throwing **`Cannot add core after closing`** from inside a synchronous `EventEmitter` callback (uncaught).

In CoMapeo mobile this latched the embedded backend into a permanent `ERROR` state, which the frontend then re-threw on every subsequent RPC send — a storm of fatal/ErrorBoundary crashes (Sentry COMAPEO-20J / 20H / 213).

### Changes
- Store the bound `add-core` listener as a private field and `coreManager.off('add-core', …)` it in `close()` before closing the indexer.
- Regression test: `close()` removes the add-core listener (`listenerCount` returns to baseline).

### Related
- Complementary hardening: digidem/multi-core-indexer#49 makes `addCore()` a no-op when closed, so a late add-core during teardown can't throw even if a caller misses removing a listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)