### PR TITLE
fix: fix display of error message for UnknownError

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -554,7 +554,7 @@ export function getErrorCode(maybeError) {
  */
 export function ensureKnownError(err) {
   if (typeof err.status !== 'number' || typeof err.code !== 'string') {
-    return new UnknownError(err)
+    return new UnknownError({ err })
   }
   return err
 }


### PR DESCRIPTION
The usage of `UnknownError` passes the error directly instead of as an object with an `err` field, causing the error's message to not be expanded. Example of the error not being displayed properly:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6328b003-7a7a-470e-ba0d-c87352e05384" />
