### PR TITLE
fix(ci): allow prerelease workflow to run on unmerged PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,12 @@ on:
 jobs:
   release:
     if: >-
-      ${{
-        (
-          startsWith(github.event.inputs.semver, 'pre') ||
-          github.ref == format(
-            'refs/heads/{0}',
-            github.event.repository.default_branch
-          )
-        ) &&
-        (
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.merged &&
-            github.event.pull_request.user.login == 'optic-release-automation[bot]'
-          )
-        )
-      }}
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.login == 'optic-release-automation[bot]'
+        && startsWith(github.event.pull_request.title, '[OPTIC-RELEASE-AUTOMATION]')
+        && (!github.event.pull_request.merged
+          || github.event.pull_request.base.ref == 'main'
+          || contains(github.event.pull_request.head.ref, '-pre.')))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Replace the release job's if condition with the working version from comapeo-ipc. The old condition required pull_request.merged == true, which blocked prerelease PRs (optic publishes on PR close, not merge).

Changes:
- Add startsWith(title, '[OPTIC-RELEASE-AUTOMATION]') guard
- Allow unmerged PRs when head branch contains '-pre.'