### PR TITLE
fix(sync): don't use `core.update()` for peer `'started'` - use peer's Synchronize instead

### DIFF
--- a/src/sync/core-sync-state.js
+++ b/src/sync/core-sync-state.js
@@ -44,6 +44,15 @@ import { InvalidBitfieldIndexError } from '../errors.js'
 const WANT_FULL = 2 ** 32 - 1
 
 /**
+ * How long after `peer-add` to wait for the peer's first Synchronize message
+ * before treating the peer as started with its channel-level state unknown
+ * (see `#onPeerAdd`). Normally the Synchronize arrives in the same batch as
+ * the channel open, so this is only hit when a channel close/open crossing
+ * swallowed the handshake.
+ */
+const FIRST_SYNC_FALLBACK_MS = 5_000
+
+/**
  * Track sync state for a core identified by `discoveryId`. Can start tracking
  * state before the core instance exists locally, via the "preHave" messages
  * received over the project creator core.
@@ -279,12 +288,6 @@ export class CoreSyncState {
     const peerState = this.#getOrCreatePeerState(peerId)
     peerState.status = 'starting'
 
-    this.#core?.update({ wait: true }).then(() => {
-      peerState.status = 'started'
-      peerState.contiguousLength = peer.remoteContiguousLength
-      this.#update()
-    })
-
     // A peer can have a pre-emptive "have" bitfield received via an extension
     // message, but when the peer actually connects then we switch to the actual
     // bitfield from the peer object
@@ -294,7 +297,9 @@ export class CoreSyncState {
     this.#update()
 
     // We want to emit state when a peer's bitfield changes, which can happen as
-    // a result of these two internal calls.
+    // a result of these two internal calls. Hypercore dispatches wire messages
+    // by property lookup on this peer object (its channel's userData), so
+    // shadowing the methods on the instance is the interception point.
     const originalOnBitfield = peer.onbitfield
     const originalOnRange = peer.onrange
     peer.onbitfield = (...args) => {
@@ -306,6 +311,79 @@ export class CoreSyncState {
       originalOnRange.apply(peer, args)
       peerState.contiguousLength = peer.remoteContiguousLength
       this.#update()
+    }
+
+    // The peer is "started" once its first Synchronize message has been
+    // processed (hypercore sets `peer.remoteSynced`): only then do we know
+    // the peer's length and fork, so only then can counts about this peer be
+    // trusted. Every channel sends a Synchronize immediately on open, so this
+    // always arrives. Do NOT use `core.update({ wait: true })` as a proxy for
+    // this: it answers a core-global question ("am I up to date with the
+    // swarm?") which (a) resolves immediately for writable cores, (b)
+    // resolves for all waiters when *any* peer supplies an upgrade, and (c)
+    // samples at most 3 peers (hypercore's MAX_PEERS_UPGRADE) — so it can
+    // report a peer as started before we have heard anything from it.
+    const markStarted = () => {
+      peerState.status = 'started'
+      peerState.contiguousLength = peer.remoteContiguousLength
+      this.#update()
+    }
+    if (peer.remoteSynced) {
+      // Defensive only — not reachable in production wiring: cores are
+      // attached synchronously on the core manager's 'add-core' event (or at
+      // construction), before a channel handshake could possibly complete,
+      // so peers replayed by `attachCore` have never synced yet. But nothing
+      // in this class enforces that callers attach before handshakes
+      // complete, so handle an already-synced peer correctly rather than
+      // waiting for a Synchronize that already happened.
+      markStarted()
+    } else {
+      const originalOnSync = peer.onsync
+      peer.onsync = (...args) => {
+        const result = originalOnSync.apply(peer, args)
+        // `remoteSynced` is set synchronously at the top of `onsync`
+        if (peer.remoteSynced) {
+          if (peerState.status === 'starting') {
+            clearTimeout(firstSyncFallback)
+            markStarted()
+          } else {
+            // A Synchronize arriving after the fallback below fired still
+            // carries state (the peer's length and fork), so re-derive
+            peerState.contiguousLength = peer.remoteContiguousLength
+            this.#update()
+          }
+        }
+        return result
+      }
+      // The remote sends its first Synchronize as soon as the channel
+      // opens, so normally this timer never fires. The exception is a
+      // renegotiation bug in hypercore/protomux (their `Peer#onclose` has a
+      // TODO about it): when both sides close and re-open a channel at the
+      // same time — e.g. a namespace toggling off and on around a role
+      // change — the messages cross and the remote keeps its old session,
+      // never re-sending its state, so we would wait forever. This is not
+      // repairable from here (no message forces a re-send, and
+      // closing/re-opening the channel from this layer destabilizes the
+      // replication layers that own it), only upstream. So stop waiting and
+      // mark the peer started. The cost is the same as any reconnect, and
+      // the same as the previous `core.update()`-based code: until this
+      // peer reconnects we only know about this core what its pre-haves
+      // told us (what it had at connect, plus its own writer-core appends),
+      // not blocks it downloaded from third devices mid-session, so its
+      // `have`/`wanted` counts can run low.
+      const firstSyncFallback = setTimeout(() => {
+        if (peer.remoteSynced || peer.removed) return
+        if (peerState.status !== 'starting') return
+        this.#l.log(
+          'Peer %S sent no Synchronize %dms after channel open, marking started',
+          peerId,
+          FIRST_SYNC_FALLBACK_MS
+        )
+        markStarted()
+      }, FIRST_SYNC_FALLBACK_MS)
+      // Don't keep the process alive for this; it matters only while the
+      // connection (which itself holds the process open) is live
+      firstSyncFallback.unref?.()
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,8 +166,25 @@ export type HypercorePeer = {
   remotePublicKey: Buffer
   remoteBitfield: HypercoreRemoteBitfield
   remoteContiguousLength: number
+  /**
+   * Set (synchronously) when the peer's first Synchronize wire message is
+   * processed, i.e. once we know the peer's length and fork.
+   */
+  remoteSynced: boolean
+  /** Set when the peer's channel has closed and it was removed from the replicator. */
+  removed: boolean
   onbitfield: (options: { start: number; bitfield: Buffer }) => void
   onrange: (options: { drop: boolean; start: number; length: number }) => void
+  onsync: (options: {
+    fork: number
+    length: number
+    remoteLength: number
+    canUpgrade: boolean
+    uploading: boolean
+    downloading: boolean
+    hasManifest: boolean
+    allowPush: boolean
+  }) => Promise<void>
 }
 
 type ProtocolStream = Omit<NoiseStream, 'userData'> & {

--- a/test/sync/core-sync-state.js
+++ b/test/sync/core-sync-state.js
@@ -463,6 +463,265 @@ test('CoreReplicationState', async (t) => {
   }
 })
 
+test('peer status stays "starting" until that peer\'s first Synchronize (writable core)', async (t) => {
+  // `core.update({ wait: true })` resolves immediately for writable cores
+  // (hypercore short-circuits: a writer is always "up to date"), so it can
+  // never be a signal that a *peer* has completed its length handshake.
+  const localCore = await createCore(t)
+  await localCore.append(['a', 'b', 'c'])
+
+  const emitter = new EventEmitter()
+  const crs = new CoreSyncState({
+    onUpdate: () => emitter.emit('update'),
+    peerSyncControllers: new Map(),
+    namespace: 'auth',
+    deviceId: '',
+    hasDownloadFilter: () => false,
+  })
+  crs.attachCore(localCore)
+
+  const hold = holdSynchronize(localCore)
+  const remoteCore = await createCore(t, localCore.key)
+  const kp2 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1))
+  const peerId = kp2.publicKey.toString('hex')
+  const destroy = replicate(localCore, remoteCore, { kp2 })
+  t.after(destroy)
+
+  await once(localCore, 'peer-add')
+  // Allow any (incorrect) async continuations to settle
+  await new Promise((res) => setTimeout(res, 200))
+
+  assert.equal(
+    localCore.peers[0].remoteSynced,
+    false,
+    'sanity: the peer has not sent its first Synchronize yet'
+  )
+  assert.equal(
+    crs.getState().remoteStates[peerId].status,
+    'starting',
+    'peer is still "starting" before its first Synchronize'
+  )
+
+  hold.release()
+  await waitForStatus(crs, emitter, peerId, 'started')
+  assert.equal(
+    localCore.peers[0].remoteSynced,
+    true,
+    'sanity: Synchronize has now been processed'
+  )
+})
+
+test('peer status stays "starting" while another peer supplies an upgrade', async (t) => {
+  // `core.update({ wait: true })` resolves for *all* waiters as soon as any
+  // peer advances the core's length, so on an actively-transferring core a
+  // newly-connected peer would be marked "started" before it has said
+  // anything at all.
+  const writerCore = await createCore(t)
+  await writerCore.append(['a', 'b', 'c'])
+  const localCore = await createCore(t, writerCore.key)
+
+  const emitter = new EventEmitter()
+  const crs = new CoreSyncState({
+    onUpdate: () => emitter.emit('update'),
+    peerSyncControllers: new Map(),
+    namespace: 'auth',
+    deviceId: '',
+    hasDownloadFilter: () => false,
+  })
+  crs.attachCore(localCore)
+
+  // Sync fully with the writer first
+  const kpWriter = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1))
+  const destroyWriterConn = replicate(localCore, writerCore, {
+    kp2: kpWriter,
+  })
+  t.after(destroyWriterConn)
+  localCore.download({ start: 0, end: -1 })
+  await once(localCore, 'peer-add')
+  await waitFor(() => localCore.contiguousLength === 3)
+
+  // Now a new peer connects, but its first Synchronize is withheld
+  const hold = holdSynchronize(localCore)
+  const newPeerCore = await createCore(t, writerCore.key)
+  const kpNew = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(2))
+  const newPeerId = kpNew.publicKey.toString('hex')
+  const destroyNewConn = replicate(localCore, newPeerCore, { kp2: kpNew })
+  t.after(destroyNewConn)
+  await once(localCore, 'peer-add')
+
+  // The writer appends and we download it: the core's length advances, which
+  // resolves every pending `core.update()` — but tells us nothing about the
+  // new peer
+  await writerCore.append('d')
+  await waitFor(() => localCore.contiguousLength === 4)
+  await new Promise((res) => setTimeout(res, 200))
+
+  const newPeer = localCore.peers.find((p) =>
+    p.remotePublicKey.equals(kpNew.publicKey)
+  )
+  assert(newPeer, 'sanity: new peer is connected')
+  assert.equal(
+    newPeer.remoteSynced,
+    false,
+    'sanity: the new peer has not sent its first Synchronize yet'
+  )
+  assert.equal(
+    crs.getState().remoteStates[newPeerId].status,
+    'starting',
+    'new peer is still "starting" before its first Synchronize'
+  )
+
+  hold.release()
+  await waitForStatus(crs, emitter, newPeerId, 'started')
+})
+
+test('peer status stays "starting" for a 4th concurrent peer (hypercore upgrade quorum cap)', async (t) => {
+  // `core.update({ wait: true })` samples at most MAX_PEERS_UPGRADE (3)
+  // peers, so with 4+ connected peers it can resolve without ever
+  // consulting the 4th peer's handshake — it must not be treated as a
+  // per-peer "handshake complete" signal.
+  const keySource = await createCore(t) // never replicated; provides a key
+  const localCore = await createCore(t, keySource.key)
+
+  const emitter = new EventEmitter()
+  const crs = new CoreSyncState({
+    onUpdate: () => emitter.emit('update'),
+    peerSyncControllers: new Map(),
+    namespace: 'auth',
+    deviceId: '',
+    hasDownloadFilter: () => false,
+  })
+  crs.attachCore(localCore)
+
+  // Three peers, fully synced
+  for (let i = 1; i <= 3; i++) {
+    const remoteCore = await createCore(t, keySource.key)
+    const kp2 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(i))
+    const destroy = replicate(localCore, remoteCore, { kp2 })
+    t.after(destroy)
+  }
+  await waitFor(
+    () =>
+      localCore.peers.length === 3 &&
+      localCore.peers.every((p) => p.remoteSynced)
+  )
+
+  // A 4th peer connects, but its first Synchronize is withheld
+  const hold = holdSynchronize(localCore, { maxPeers: 1 })
+  const fourthCore = await createCore(t, keySource.key)
+  const kp4 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(4))
+  const fourthPeerId = kp4.publicKey.toString('hex')
+  const destroy = replicate(localCore, fourthCore, { kp2: kp4 })
+  t.after(destroy)
+  await once(localCore, 'peer-add')
+
+  // A 5th peer connects and syncs normally: its handshake re-evaluates
+  // hypercore's shared upgrade request, which samples only the first
+  // MAX_PEERS_UPGRADE peers — never the still-silent 4th
+  const fifthCore = await createCore(t, keySource.key)
+  const kp5 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(5))
+  const destroy5 = replicate(localCore, fifthCore, { kp2: kp5 })
+  t.after(destroy5)
+  await waitFor(() =>
+    localCore.peers.some(
+      (p) => p.remotePublicKey.equals(kp5.publicKey) && p.remoteSynced
+    )
+  )
+  // Allow any (incorrect) async continuations to settle
+  await new Promise((res) => setTimeout(res, 300))
+
+  assert.equal(
+    crs.getState().remoteStates[fourthPeerId].status,
+    'starting',
+    '4th peer is still "starting" before its first Synchronize'
+  )
+
+  hold.release()
+  await waitForStatus(crs, emitter, fourthPeerId, 'started')
+})
+
+/**
+ * Intercept and queue the first Synchronize message(s) from peers that are
+ * added to `core` after this is called, so tests can hold a peer in the
+ * "channel open, length handshake not yet processed" state. Uses the same
+ * interception point as production code: hypercore dispatches wire messages
+ * by property lookup on the peer object, so shadowing `onsync` on the
+ * instance sees every message.
+ *
+ * @param {import('hypercore')} core
+ * @param {object} [opts]
+ * @param {number} [opts.maxPeers] only hold the first `maxPeers` peers added
+ * after this call (later peers' messages flow normally)
+ */
+function holdSynchronize(core, { maxPeers = Infinity } = {}) {
+  /** @type {Array<() => unknown>} */
+  const queued = []
+  /** @type {Array<() => void>} */
+  const restores = []
+  let held = true
+  let heldPeerCount = 0
+  /** @param {import('../../src/types.js').HypercorePeer} peer */
+  const onPeerAdd = (peer) => {
+    if (heldPeerCount >= maxPeers) return
+    heldPeerCount++
+    const originalOnSync = peer.onsync
+    peer.onsync = (...args) => {
+      if (!held) return originalOnSync.apply(peer, args)
+      queued.push(() => originalOnSync.apply(peer, args))
+      return Promise.resolve()
+    }
+    restores.push(() => {
+      peer.onsync = originalOnSync
+    })
+  }
+  core.on('peer-add', onPeerAdd)
+  return {
+    release() {
+      held = false
+      core.off('peer-add', onPeerAdd)
+      for (const apply of queued) apply()
+      for (const restore of restores) restore()
+    },
+  }
+}
+
+/**
+ * @param {() => boolean} condition
+ * @param {number} [timeoutMs]
+ */
+async function waitFor(condition, timeoutMs = 1000) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('Timed out waiting for condition')
+    }
+    await new Promise((res) => setTimeout(res, 10))
+  }
+}
+
+/**
+ * Wait until the peer's status matches, driven by state update events.
+ *
+ * @param {CoreSyncState} crs
+ * @param {EventEmitter} emitter
+ * @param {string} peerId
+ * @param {import('../../src/sync/core-sync-state.js').PeerNamespaceState['status']} status
+ * @param {number} [timeoutMs]
+ */
+async function waitForStatus(crs, emitter, peerId, status, timeoutMs = 1000) {
+  await pTimeout(
+    (async () => {
+      while (crs.getState().remoteStates[peerId]?.status !== status) {
+        await once(emitter, 'update')
+      }
+    })(),
+    {
+      milliseconds: timeoutMs,
+      message: `Timed out waiting for status ${status}`,
+    }
+  )
+}
+
 test('bitCount32', () => {
   const testCases = new Set([0, 2 ** 32 - 1])
   for (let i = 0; i < 32; i++) {

--- a/test/sync/core-sync-state.js
+++ b/test/sync/core-sync-state.js
@@ -640,6 +640,81 @@ test('peer status stays "starting" for a 4th concurrent peer (hypercore upgrade 
   await waitForStatus(crs, emitter, fourthPeerId, 'started')
 })
 
+test('peer status falls back to "started" if the first Synchronize never arrives', async (t) => {
+  // A channel close/open crossing can leave the remote never re-sending its
+  // Synchronize (it believes its old session is still live) — see the
+  // comment in CoreSyncState's #onPeerAdd. A live channel in that state
+  // must not block sync state forever: after a fallback timeout the peer is
+  // treated as started, with its blocks still counted via pre-haves.
+  const localCore = await createCore(t)
+  await localCore.append(['a', 'b', 'c'])
+
+  const emitter = new EventEmitter()
+  const crs = new CoreSyncState({
+    onUpdate: () => emitter.emit('update'),
+    peerSyncControllers: new Map(),
+    namespace: 'auth',
+    deviceId: '',
+    hasDownloadFilter: () => false,
+  })
+  crs.attachCore(localCore)
+
+  // Never released: the Synchronize never arrives
+  holdSynchronize(localCore)
+  const remoteCore = await createCore(t, localCore.key)
+  const kp2 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1))
+  const peerId = kp2.publicKey.toString('hex')
+  const destroy = replicate(localCore, remoteCore, { kp2 })
+  t.after(destroy)
+
+  await once(localCore, 'peer-add')
+  assert.equal(
+    crs.getState().remoteStates[peerId].status,
+    'starting',
+    'peer is "starting" while the Synchronize is missing'
+  )
+
+  // 5000ms fallback (FIRST_SYNC_FALLBACK_MS) plus margin
+  await waitForStatus(crs, emitter, peerId, 'started', 8_000)
+  const livePeer = localCore.peers.find((p) =>
+    p.remotePublicKey.equals(kp2.publicKey)
+  )
+  assert.equal(
+    livePeer?.remoteSynced,
+    false,
+    'sanity: "started" came from the fallback, not a Synchronize'
+  )
+})
+
+test('peer status becomes "started" for a peer that synced before the core was attached', async (t) => {
+  // Defensive invariant: production wiring attaches cores before their
+  // channel handshakes can complete, but nothing in CoreSyncState enforces
+  // that. A peer whose Synchronize was already processed when the core is
+  // attached must become "started" without waiting for another message.
+  const localCore = await createCore(t)
+  await localCore.append(['a', 'b', 'c'])
+  const remoteCore = await createCore(t, localCore.key)
+  const kp2 = NoiseSecretStream.keyPair(Buffer.allocUnsafe(32).fill(1))
+  const peerId = kp2.publicKey.toString('hex')
+  const destroy = replicate(localCore, remoteCore, { kp2 })
+  t.after(destroy)
+
+  await once(localCore, 'peer-add')
+  await waitFor(() => localCore.peers[0].remoteSynced === true)
+
+  const emitter = new EventEmitter()
+  const crs = new CoreSyncState({
+    onUpdate: () => emitter.emit('update'),
+    peerSyncControllers: new Map(),
+    namespace: 'auth',
+    deviceId: '',
+    hasDownloadFilter: () => false,
+  })
+  crs.attachCore(localCore)
+
+  await waitForStatus(crs, emitter, peerId, 'started')
+})
+
 /**
  * Intercept and queue the first Synchronize message(s) from peers that are
  * added to `core` after this is called, so tests can hold a peer in the


### PR DESCRIPTION
## Problem

`CoreSyncState` marked a peer's per-core status `'started'` when `core.update({ wait: true })` resolved. That call answers a **core-global** question — "am I up to date with the swarm?" — not "has *this peer* completed its length handshake". Three ways the two diverge (all verified against hypercore 11.30.2 source):

1. **Writable cores short-circuit**: `update()` resolves immediately for a writer (`hypercore/index.js:733`), so peers on our own writer cores were marked `'started'` before they had sent anything.
2. **Any upgrade resolves all waiters**: every concurrent `update()` attaches to one shared upgrade request, resolved as soon as *any* peer advances the core's length (`replicator.js` `onupgrade()` → `_resolveUpgradeRequest`). On an actively-transferring core, a newly-connected peer was marked `'started'` the moment the next block batch landed — from someone else.
3. **The quorum cap**: `_checkUpgradeIfAvailable()` samples at most `MAX_PEERS_UPGRADE = 3` peers, so with 4+ connected peers and any ambient traffic, the shared request resolves without ever consulting a new peer's handshake.

A prematurely-`'started'` peer reads as "has nothing, wants everything". Where we hold no blocks for that core, that is indistinguishable from "nothing left to sync", so `isSynced()` / `waitForSync()` / autostop could report or act on completion before hearing from the peer. Field deployments routinely have 4+ concurrent peers and in-flight transfers, so modes 2 and 3 are everyday occurrences, not edge cases.

## Fix

Flip status to `'started'` when the peer's **own** first `Synchronize` wire message is processed — hypercore records exactly this per-peer fact as `peer.remoteSynced`, set synchronously at the top of `peer.onsync()`. We intercept by shadowing `onsync` on the peer instance, the same interception already used for `onbitfield`/`onrange` (hypercore dispatches wire messages by property lookup on the channel's userData).

**The fallback, and why it is safe.** One real case exists where the first `Synchronize` never arrives on a live channel: a **channel close/open crossing** on the same protomux — both sides disable and re-enable a namespace around the same time, which routinely happens during the invite flow's capability churn. One side ends up with a fresh peer holding no baseline while the remote believes its old session is still live, so it never re-sends its state, and hypercore does not recover on its own. There is no reliable in-band repair (hypercore replies to an incoming sync only when it has something newer; replies to wants only with bitfield pages it has; and the duplicate channel open is dropped by protomux before hypercore sees it — verified empirically). Forcing a channel renegotiation from the observation layer was tried and reverted: it destabilizes the layers that own the channel lifecycle (the re-replicate can silently fail to establish a channel, stranding the peer — this hung CI). So after 5s the peer is treated as `'started'` with its channel-level state unknown.

This is not fabricated sync state, because the counts this status gates don't depend on the channel handshake alone: **a peer's blocks are counted from its pre-have bitfields** (broadcast over the project creator core at connect and on append) **merged with the channel-level bitfield** (`PeerState#haveWord`). A peer that has data is counted correctly even when its channel handshake was lost to a crossing; the status flip just stops gating counts that are already correct. A `Synchronize` arriving after the fallback still updates state. The root fix is upstream: protomux channel renegotiation needs a close reason / channel generation (hypercore's own `Peer#onclose` has a TODO to this effect).

This also removes an unhandled-rejection hazard: the old `.then()` had no rejection handler, and hypercore rejects pending `update()` calls when a core closes.

`src/types.ts` gains `remoteSynced`, `removed` and `onsync` on the `HypercorePeer` subset type.

## Tests

New tests hold a peer in the "channel open, `Synchronize` not yet processed" state via a `holdSynchronize()` helper (queues the intercepted message; deterministic, verified stable across repeated runs). Each of the three failure modes has a regression test verified to fail against the old implementation:

- **writable core** (mode 1): status must stay `'starting'` while the peer's `Synchronize` is withheld;
- **upgrade from another peer** (mode 2): a writer append/download must not flip a new, still-silent peer to `'started'`;
- **quorum cap** (mode 3): with three synced peers and ambient traffic from a fifth, a still-silent fourth peer must stay `'starting'`;
- **fallback**: a peer whose `Synchronize` never arrives becomes `'started'` after the fallback rather than blocking forever (asserted to have happened *without* a `Synchronize`);
- **attach-late**: a defensive invariant — a peer already synced when the core is attached becomes `'started'` immediately. Not reachable in production wiring (cores attach synchronously on `'add-core'`, before a channel handshake can complete; verified empirically across the connection-heavy e2e suites), but nothing in `CoreSyncState` enforces attach-before-handshake, so the class handles it.

Verified on Node 18 and 22: full unit suite, `tsc`, eslint, prettier, and the full e2e suite including the invite-flow crossing cases (`test-e2e/members.js` "remove member from project, add them back", `test-e2e/project-leave.js` "Member can join project again after leaving").

## Follow-ups

- The same pattern exists in the rewritten `#onPeerAdd` on `experiment/sync-refactor` (#1304), where it drives the `opening`/`open` channel states — it needs the equivalent port (per-peer `Synchronize` gate + fallback), otherwise its `openingChannels > 0` completion gate hangs the same way in remove/re-add flows.
- Report the renegotiation crossing upstream: hypercore's `Peer#onclose` has a TODO acknowledging the renegotiation is messy ("add a CLOSE_REASON to mux so we can make this cleaner"); a mux-level close reason / channel generation would fix this at the root, and would let the 5s fallback be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzqT9t19AV5voYFM2vYV8h