### PR TITLE
fix: no double close event on projects

### DIFF
--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -610,8 +610,6 @@ export class MapeoProject extends ReadyResource {
     await this.#coreManager.close()
 
     this.#sqlite.close()
-
-    this.emit('close')
   }
 
   /**


### PR DESCRIPTION
fix for double close event bug mentioned in https://github.com/digidem/comapeo-ipc/pull/88

This started when we made MapeoProject a ReadyResource which emits these events itself.