### PR TITLE
Feat/left project error data

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -418,6 +418,12 @@ export const ExhaustivenessError = createErrorClass({
   status: 500,
 })
 
+export const ProjectLeftError = createErrorClass({
+  code: 'PROJECT_LEFT_ERROR',
+  message: 'Project has been left',
+  status: 403,
+})
+
 export const PeerNotFoundError = createErrorClass({
   code: 'PEER_NOT_FOUND_ERROR',
   message: 'Peer not found',

--- a/src/mapeo-manager.js
+++ b/src/mapeo-manager.js
@@ -13,7 +13,6 @@ import { IndexWriter } from './index-writer/index.js'
 import {
   MapeoProject,
   kBlobStore,
-  kClearData,
   kProjectLeave,
   kSetIsArchiveDevice,
   kSetOwnDeviceInfo,
@@ -588,7 +587,7 @@ export class MapeoManager extends TypedEmitter {
     // trying to create a project instance if we have marked the project as
     // "left".
     if (projectKeysTableResult.hasLeftProject) {
-      await project[kClearData]()
+      await project[kProjectLeave]()
     }
 
     // 3. Keep track of project instance as we know it's a properly existing project

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -969,6 +969,7 @@ export class MapeoProject extends ReadyResource {
     })
   }
 
+  /** Leave the project and clear the data. Does not re-assign role when already left */
   async [kProjectLeave]() {
     const { roleId } = await this.$getOwnRole()
 

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -121,19 +121,22 @@ const EMPTY_PROJECT_SETTINGS = Object.freeze({ sendStats: false })
  */
 
 /**
- * @param {any} target
- * @returns {any}
+ * @template T
+ * @param {T} target
+ * @returns {T}
  */
 function createProjectLeftMock(target) {
-  return new Proxy(target, {
-    get(obj, prop) {
-      const value = Reflect.get(obj, prop)
-      if (typeof value === 'function') {
-        return () => Promise.reject(new ProjectLeftError())
-      }
-      return value
-    },
-  })
+  return /** @type {T} */ (
+    new Proxy(/** @type {object} */ (target), {
+      get(obj, prop) {
+        const value = Reflect.get(obj, prop)
+        if (typeof value === 'function') {
+          return () => Promise.reject(new ProjectLeftError())
+        }
+        return value
+      },
+    })
+  )
 }
 
 export class MapeoProject extends ReadyResource {

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -970,9 +970,9 @@ export class MapeoProject extends ReadyResource {
   }
 
   async [kProjectLeave]() {
-    const ownRole = await this.$getOwnRole()
+    const { roleId } = await this.$getOwnRole()
 
-    if (ownRole.roleId !== BLOCKED_ROLE_ID) {
+    if (roleId !== BLOCKED_ROLE_ID && roleId !== LEFT_ROLE_ID) {
       await this.#roles.assignRole(this.#deviceId, LEFT_ROLE_ID)
     }
 

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -63,6 +63,7 @@ import {
   nullIfNotFound,
   MultipleCategoryImportsError,
   UnexpectedDocSchemaError,
+  ProjectLeftError,
 } from './errors.js'
 import { WebSocket } from 'ws'
 
@@ -118,6 +119,23 @@ const EMPTY_PROJECT_SETTINGS = Object.freeze({ sendStats: false })
 /**
  * @type {ReadyResource & TypedEmitter<ProjectEvents>}
  */
+
+/**
+ * @param {any} target
+ * @returns {any}
+ */
+function createProjectLeftMock(target) {
+  return new Proxy(target, {
+    get(obj, prop) {
+      const value = Reflect.get(obj, prop)
+      if (typeof value === 'function') {
+        return () => Promise.reject(new ProjectLeftError())
+      }
+      return value
+    },
+  })
+}
+
 export class MapeoProject extends ReadyResource {
   #projectKey
   #deviceId
@@ -141,6 +159,8 @@ export class MapeoProject extends ReadyResource {
   #l
   /** @type {Boolean} this avoids loading multiple configs in parallel */
   #importingCategories
+  /** @type {Boolean} */
+  #hasLeft = false
 
   static EMPTY_PROJECT_SETTINGS = EMPTY_PROJECT_SETTINGS
   #getFallbackProjectInfo
@@ -666,19 +686,26 @@ export class MapeoProject extends ReadyResource {
   }
 
   get observation() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#dataTypes.observation)
     return this.#dataTypes.observation
   }
   get track() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#dataTypes.track)
     return this.#dataTypes.track
   }
   get preset() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#dataTypes.preset)
     return this.#dataTypes.preset
   }
   get field() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#dataTypes.field)
     return this.#dataTypes.field
   }
 
   get remoteDetectionAlert() {
+    if (this.#hasLeft) {
+      return createProjectLeftMock(this.#dataTypes.remoteDetectionAlert)
+    }
     return this.#dataTypes.remoteDetectionAlert
   }
 
@@ -691,6 +718,7 @@ export class MapeoProject extends ReadyResource {
   }
 
   get $translation() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#translationApi)
     return this.#translationApi
   }
 
@@ -862,6 +890,7 @@ export class MapeoProject extends ReadyResource {
    * @returns {import('./icon-api.js').IconApi}
    */
   get $icons() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#iconApi)
     return this.#iconApi
   }
 
@@ -936,6 +965,7 @@ export class MapeoProject extends ReadyResource {
       await this.#roles.assignRole(this.#deviceId, LEFT_ROLE_ID)
     }
 
+    this.#hasLeft = true
     await this[kClearData]()
   }
 

--- a/src/mapeo-project.js
+++ b/src/mapeo-project.js
@@ -148,6 +148,7 @@ export class MapeoProject extends ReadyResource {
   #dataStores
   #dataTypes
   #blobStore
+  #blobApi
   #coreOwnership
   #roles
   #sqlite
@@ -456,7 +457,7 @@ export class MapeoProject extends ReadyResource {
       console.error('BlobStore error', e)
     })
 
-    this.$blobs = new BlobApi({
+    this.#blobApi = new BlobApi({
       blobStore: this.#blobStore,
       getMediaBaseUrl: async () => {
         let base = await getMediaBaseUrl('blobs')
@@ -710,7 +711,13 @@ export class MapeoProject extends ReadyResource {
     return this.#dataTypes.remoteDetectionAlert
   }
 
+  get $blobs() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#blobApi)
+    return this.#blobApi
+  }
+
   get $member() {
+    if (this.#hasLeft) return createProjectLeftMock(this.#memberApi)
     return this.#memberApi
   }
 
@@ -728,6 +735,7 @@ export class MapeoProject extends ReadyResource {
    * @returns {Promise<EditableProjectSettings>}
    */
   async $setProjectSettings(settings) {
+    if (this.#hasLeft) throw new ProjectLeftError()
     const { projectSettings } = this.#dataTypes
 
     const existing = await projectSettings
@@ -930,6 +938,7 @@ export class MapeoProject extends ReadyResource {
     exportFolder,
     { observations = true, tracks = true, lang } = {}
   ) {
+    if (this.#hasLeft) throw new ProjectLeftError()
     return this.#dataExporter.exportGeoJSONFile(exportFolder, {
       observations,
       tracks,
@@ -951,6 +960,7 @@ export class MapeoProject extends ReadyResource {
     exportFolder,
     { observations = true, tracks = true, attachments = true, lang } = {}
   ) {
+    if (this.#hasLeft) throw new ProjectLeftError()
     return this.#dataExporter.exportZipFile(exportFolder, {
       observations,
       tracks,

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -634,8 +634,7 @@ export class MemberApi extends TypedEmitter {
   async getMany({ includeLeft = false } = {}) {
     const [allRoles, allDeviceInfo] = await Promise.all([
       this.#roles.getAll(),
-      // If we can't get info due to leave, still allow listing
-      this.#dataTypes.deviceInfo.getMany().catch(() => []),
+      this.#dataTypes.deviceInfo.getMany(),
     ])
 
     const deviceInfoByConfigCoreId = keyBy(allDeviceInfo, ({ docId }) => docId)

--- a/src/member-api.js
+++ b/src/member-api.js
@@ -634,7 +634,8 @@ export class MemberApi extends TypedEmitter {
   async getMany({ includeLeft = false } = {}) {
     const [allRoles, allDeviceInfo] = await Promise.all([
       this.#roles.getAll(),
-      this.#dataTypes.deviceInfo.getMany(),
+      // If we can't get info due to leave, still allow listing
+      this.#dataTypes.deviceInfo.getMany().catch(() => []),
     ])
 
     const deviceInfoByConfigCoreId = keyBy(allDeviceInfo, ({ docId }) => docId)

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import * as fs from 'node:fs/promises'
+import { randomBytes } from 'node:crypto'
 import { temporaryDirectory } from 'tempy'
 
 import { generate } from '@mapeo/mock-data'
@@ -285,7 +286,16 @@ test('all data and config getters throw ProjectLeftError after leaving', async (
     ['$setProjectSettings', () => project.$setProjectSettings({ name: 'x' })],
     ['exportGeoJSONFile', () => project.exportGeoJSONFile('/tmp')],
     ['exportZipFile', () => project.exportZipFile('/tmp')],
-    ['$blobs', () => project.$blobs.getUrl('fake-id')],
+    [
+      '$blobs',
+      () =>
+        project.$blobs.getUrl({
+          driveId: randomBytes(32).toString('hex'),
+          name: randomBytes(8).toString('hex'),
+          type: 'video',
+          variant: 'original',
+        }),
+    ],
   ]
 
   for (const [name, fn] of projectLeftGetters) {

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -251,6 +251,48 @@ test('Data access after leaving project', async (t) => {
   }, 'coordinator cannot update project settings after leaving')
 })
 
+test('all data and config getters throw ProjectLeftError after leaving', async (t) => {
+  const [manager] = await createManagers(1, t)
+
+  const projectId = await manager.createProject({ name: 'mapeo' })
+  const project = await manager.getProject(projectId)
+
+  await manager.leaveProject(projectId)
+
+  /** @type {[string, () => any][]} */
+  const projectLeftGetters = [
+    ['observation', () => project.observation.getMany()],
+    ['track', () => project.track.getMany()],
+    ['remoteDetectionAlert', () => project.remoteDetectionAlert.getMany()],
+    ['preset', () => project.preset.getMany()],
+    ['field', () => project.field.getMany()],
+    ['$translation', () => project.$translation.get({})],
+    [
+      '$icons',
+      () =>
+        project.$icons.getIconUrl('example', {
+          mimeType: 'image/png',
+          pixelDensity: 1,
+          size: 'large',
+        }),
+    ],
+  ]
+
+  for (const [name, fn] of projectLeftGetters) {
+    await assert.rejects(
+      fn,
+      { name: 'ProjectLeftError' },
+      `${name} should reject`
+    )
+  }
+
+  const members = await project.$member.getMany()
+  assert(
+    Array.isArray(members),
+    '$member.getMany() should still work after leaving'
+  )
+})
+
 test('leaving a project deletes data from disk', async (t) => {
   const memberCoreStorage = temporaryDirectory()
   t.after(() =>

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -266,7 +266,12 @@ test('all data and config getters throw ProjectLeftError after leaving', async (
     ['remoteDetectionAlert', () => project.remoteDetectionAlert.getMany()],
     ['preset', () => project.preset.getMany()],
     ['field', () => project.field.getMany()],
-    ['$translation', () => project.$translation.get({})],
+    [
+      '$translation',
+      () =>
+        // @ts-ignore
+        project.$translation.get({}),
+    ],
     [
       '$icons',
       () =>

--- a/test-e2e/project-leave.js
+++ b/test-e2e/project-leave.js
@@ -281,6 +281,11 @@ test('all data and config getters throw ProjectLeftError after leaving', async (
           size: 'large',
         }),
     ],
+    ['$member', () => project.$member.getMany()],
+    ['$setProjectSettings', () => project.$setProjectSettings({ name: 'x' })],
+    ['exportGeoJSONFile', () => project.exportGeoJSONFile('/tmp')],
+    ['exportZipFile', () => project.exportZipFile('/tmp')],
+    ['$blobs', () => project.$blobs.getUrl('fake-id')],
   ]
 
   for (const [name, fn] of projectLeftGetters) {
@@ -290,12 +295,6 @@ test('all data and config getters throw ProjectLeftError after leaving', async (
       `${name} should reject`
     )
   }
-
-  const members = await project.$member.getMany()
-  assert(
-    Array.isArray(members),
-    '$member.getMany() should still work after leaving'
-  )
 })
 
 test('leaving a project deletes data from disk', async (t) => {

--- a/test-e2e/utils.js
+++ b/test-e2e/utils.js
@@ -743,7 +743,10 @@ export async function getDiskUsage(filePath) {
   await Promise.all(
     dirents.map(async (dirent) => {
       if (!dirent.isFile()) return 0
-      const dirFilePath = path.join(dirent.path, dirent.name)
+      const dirFilePath = path.join(
+        dirent.parentPath ?? dirent.path,
+        dirent.name
+      )
       const dirStats = await fsPromises.stat(dirFilePath)
       result += dirStats.size
     })


### PR DESCRIPTION
closes https://github.com/digidem/comapeo-core/issues/1313

We should have reasonable errors after we leave a project.
Also we should be able to do a basic member list even if their names are cleared.