### PR TITLE
feat: updates to types related to hypercore migration

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -256,11 +256,18 @@ export async function needsMigration(corestorePath) {
 }
 
 /**
+ * @typedef {{ shouldUpgrade: true, reason: typeof MIGRATION_REASON_NEEDS_UPGRADE, useFallback: false }} ShouldUpgrade
+ * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_ALREADY_UPGRADED, useFallback: false }} AlreadyUpgraded
+ * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_NO_SPACE, spaceNeeded: number, useFallback: true }} NeedsSpace
+ * @typedef {ShouldUpgrade | AlreadyUpgraded | NeedsSpace} MigrationCheckResult
+ */
+
+/**
  * Checks if it makes sense to migrate. Are we already migrated? Do we have enough storage to migrate?
  * Available space needs to be at least 1.5x the largest core
  * @param {string} managerPath Folder where the MapeoManager stores its data
  * @param {number} availableStorage How much storage is available to migrate.
- * @returns {Promise<{shouldUpgrade:boolean, useFallback: boolean, reason: MigrationReason, spaceNeeded?: number}>}
+ * @returns {Promise<MigrationCheckResult>}
  */
 export async function checkShouldMigrate(managerPath, availableStorage) {
   const projectIds = await listProjectsFromStorage(managerPath)

--- a/src/migration.js
+++ b/src/migration.js
@@ -156,6 +156,8 @@ export function makeDefaultCorestoreStorage(path) {
   })
 }
 
+/** @typedef {{ migrated: true } | { migrated: false, error: Error}} MigrationResult */
+
 /**
  * Run the hypercore-storage migration (v0 -> v1) for all projects in a MapeoManager storage folder.
  *
@@ -165,7 +167,7 @@ export function makeDefaultCorestoreStorage(path) {
  * @param {string} managerPath - Path to the MapeoManager storage folder
  * @param {(doneSoFar: number, totalCores: number) => void} [onProgress] - Callback called after each core migrates
  * @param {(path: string) => MigrationStorage} [makeStorage] - Storage factory, only overridden in tests
- * @returns {Promise<Record<string, { migrated: boolean, error?: Error }>>}
+ * @returns {Promise<Record<string, MigrationResult>>}
  *         Map of project IDs to migration status
  */
 export async function migrateStorage(
@@ -185,7 +187,7 @@ export async function migrateStorage(
     }
   }
 
-  /** @type {Record<string, { migrated: boolean, error?: Error }>} */
+  /** @type {Record<string, MigrationResult>} */
   const results = {}
   let migratedSoFar = 0
   onProgress?.(migratedSoFar, totalCoresToMigrate)

--- a/src/migration.js
+++ b/src/migration.js
@@ -10,7 +10,7 @@ export const MIGRATION_REASON_NO_SPACE = 2
 
 export const AVAILABLE_SPACE_MULTIPLIER = 1.5
 
-/** @typedef {MIGRATION_REASON_NEEDS_UPGRADE|MIGRATION_REASON_ALREADY_UPGRADED|MIGRATION_REASON_NO_SPACE} MigrationReason*/
+/** @typedef {typeof MIGRATION_REASON_NEEDS_UPGRADE | typeof MIGRATION_REASON_ALREADY_UPGRADED | typeof MIGRATION_REASON_NO_SPACE} MigrationReason*/
 
 /**
  * List all project directories in a storage folder.

--- a/src/migration.js
+++ b/src/migration.js
@@ -256,9 +256,9 @@ export async function needsMigration(corestorePath) {
 }
 
 /**
- * @typedef {{ shouldUpgrade: true, reason: typeof MIGRATION_REASON_NEEDS_UPGRADE, useFallback: false }} ShouldUpgrade
- * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_ALREADY_UPGRADED, useFallback: false }} AlreadyUpgraded
- * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_NO_SPACE, spaceNeeded: number, useFallback: true }} NeedsSpace
+ * @typedef {{ shouldUpgrade: true, reason: typeof MIGRATION_REASON_NEEDS_UPGRADE }} ShouldUpgrade
+ * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_ALREADY_UPGRADED }} AlreadyUpgraded
+ * @typedef {{ shouldUpgrade: false, reason: typeof MIGRATION_REASON_NO_SPACE, spaceNeeded: number }} NeedsSpace
  * @typedef {ShouldUpgrade | AlreadyUpgraded | NeedsSpace} MigrationCheckResult
  */
 
@@ -283,7 +283,6 @@ export async function checkShouldMigrate(managerPath, availableStorage) {
     if (requiredSpace >= availableStorage) {
       return {
         shouldUpgrade: false,
-        useFallback: true,
         reason: MIGRATION_REASON_NO_SPACE,
         spaceNeeded: requiredSpace - availableStorage,
       }
@@ -293,14 +292,12 @@ export async function checkShouldMigrate(managerPath, availableStorage) {
   if (!needsUpgrade) {
     return {
       shouldUpgrade: false,
-      useFallback: false,
       reason: MIGRATION_REASON_ALREADY_UPGRADED,
     }
   }
 
   return {
     shouldUpgrade: true,
-    useFallback: false,
     reason: MIGRATION_REASON_NEEDS_UPGRADE,
   }
 }

--- a/test-e2e/migration.js
+++ b/test-e2e/migration.js
@@ -249,9 +249,9 @@ test('migrate hypercore storage', async (t) => {
     'Should have migration results for 4 projects'
   )
 
-  for (const { error, migrated } of Object.values(migrationResults)) {
-    assert.ok(migrated, 'migration successful')
-    assert.ok(!error, 'no error after migrating')
+  for (const result of Object.values(migrationResults)) {
+    assert.ok(result.migrated, 'migration successful')
+    assert.ok(!('error' in result), 'no error after migrating')
   }
 
   // Verify each project was successfully analyzed
@@ -262,9 +262,6 @@ test('migrate hypercore storage', async (t) => {
       result.migrated === true,
       `Project ${projectId} should have successful migration`
     )
-    if (result.error) {
-      console.error(`Project ${projectId} migration error:`, result.error)
-    }
   }
 
   const { shouldUpgrade: shouldUpgradeAgain, reason: migrateAgainReason } =
@@ -367,10 +364,10 @@ test('recover from hypercore migration failing', async (t) => {
     'Should have migration results for 1 project'
   )
 
-  for (const { error, migrated } of Object.values(migrationResults)) {
-    assert.ok(!migrated, 'migration failed')
+  for (const result of Object.values(migrationResults)) {
+    assert.ok(!result.migrated, 'migration failed')
     assert.equal(
-      error?.message,
+      result.error.message,
       'An unexpected error type occurred: Error: Simulate failed write',
       'no error after migrating'
     )
@@ -385,9 +382,9 @@ test('recover from hypercore migration failing', async (t) => {
     'Should have migration results for 1 project'
   )
 
-  for (const { error, migrated } of Object.values(migrationResults)) {
-    assert.ok(!error, 'no error after migrating')
-    assert.ok(migrated, 'migration successful')
+  for (const result of Object.values(migrationResults)) {
+    assert.ok(result.migrated, 'migration successful')
+    assert.ok(!('error' in result), 'no error after migrating')
   }
 })
 
@@ -527,7 +524,7 @@ test('migrate storage after one project has already migrated', async (t) => {
     'failed project migrated successfully on retry'
   )
   assert.ok(
-    !migrationResults2[failedProjectId].error,
+    !('error' in migrationResults2[failedProjectId]),
     'failed project had no error on retry'
   )
 


### PR DESCRIPTION
Some general fixes/improvements to the types related to hypercore migration to make it easier to work with in applications.

- Fixes type defs for migration check reasons
- Introduces a discriminated union for the return type of `checkShouldMigrate()`
  - I removed the `useFallback` field in general. It seemed redundant given that it's only tied to a specific variant in the return type, such that consuming code can just check against the reason and handle it from there.
- Introduces a discriminated union for the return type of `migrateStorage()`