### PR TITLE
chore: adds Content-Range and Content-Length

### DIFF
--- a/src/blob-store/index.js
+++ b/src/blob-store/index.js
@@ -282,6 +282,8 @@ export class BlobStore extends ReadyResource {
    * @param {import('hyperdrive').HyperdriveEntry} entry Hyperdrive entry
    * @param {object} [options]
    * @param {boolean} [options.wait=false] Set to `true` to wait for a blob to download, otherwise will throw if blob is not available locally
+   * @param {number} [options.start] Byte offset to start reading from
+   * @param {number} [options.length] Number of bytes to read
    * @returns {Promise<Readable>}
    */
   async createReadStreamFromEntry(driveId, entry, options = { wait: false }) {

--- a/src/fastify-plugins/blobs.js
+++ b/src/fastify-plugins/blobs.js
@@ -99,10 +99,22 @@ async function routes(fastify, options) {
       }
 
       const { metadata } = entry.value
+      const totalLength = entry.value.blob.byteLength
+
+      // Without Content-Length (and, for seeking, Range support), iOS's
+      // AVPlayer can't determine the resource's duration and treats it as
+      // an indefinite live stream, which stalls forever instead of playing.
+      const range = parseRangeHeader(request.headers.range, totalLength)
 
       let blobStream
       try {
-        blobStream = await blobStore.createReadStreamFromEntry(driveId, entry)
+        blobStream = await blobStore.createReadStreamFromEntry(
+          driveId,
+          entry,
+          range
+            ? { wait: false, start: range.start, length: range.length }
+            : { wait: false }
+        )
       } catch (e) {
         reply.code(404)
         throw ensureKnownError(e)
@@ -119,6 +131,18 @@ async function routes(fastify, options) {
         } else {
           throw ensureKnownError(e)
         }
+      }
+
+      reply.header('Accept-Ranges', 'bytes')
+      if (range) {
+        reply.code(206)
+        reply.header(
+          'Content-Range',
+          `bytes ${range.start}-${range.end}/${totalLength}`
+        )
+        reply.header('Content-Length', range.length)
+      } else {
+        reply.header('Content-Length', totalLength)
       }
 
       // Extract the 'mimeType' property of the metadata and use it for the response header if found
@@ -148,6 +172,52 @@ async function routes(fastify, options) {
       return reply.send(blobStream)
     }
   )
+}
+
+/**
+ * Parses a single-range `Range: bytes=start-end` header (the only form
+ * clients like AVPlayer send for progressive download/seek requests).
+ * Returns null if the header is absent, malformed, or unsatisfiable, in
+ * which case the caller should fall back to serving the full resource.
+ *
+ * @param {string | undefined} rangeHeader
+ * @param {number} totalLength
+ * @returns {{ start: number, end: number, length: number } | null}
+ */
+function parseRangeHeader(rangeHeader, totalLength) {
+  if (!rangeHeader || totalLength === 0) return null
+
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader)
+  if (!match) return null
+
+  const [, startStr, endStr] = match
+  if (!startStr && !endStr) return null
+
+  let start
+  let end
+  if (startStr) {
+    start = Number(startStr)
+    end = endStr ? Number(endStr) : totalLength - 1
+  } else {
+    // Suffix range, e.g. `bytes=-500` means "the last 500 bytes"
+    const suffixLength = Number(endStr)
+    start = Math.max(0, totalLength - suffixLength)
+    end = totalLength - 1
+  }
+
+  if (
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start < 0 ||
+    start > end ||
+    start >= totalLength
+  ) {
+    return null
+  }
+
+  end = Math.min(end, totalLength - 1)
+
+  return { start, end, length: end - start + 1 }
 }
 
 /**


### PR DESCRIPTION
towards [2109](https://github.com/digidem/comapeo-mobile/issues/2109) in comapeo mobile

iOS uses AVPlayer (via Expo-Audio) to play audio within Comapeo-Mobile. The Audio returned by the fastify server was not playing at all.

The blob download route (GET /projects/:projectId/blob/...) never sent Content-Length, and didn't support Range requests. Without a known content length iOS's AVPlayer can't determine a video's duration and treats it as an indefinite live stream, which stalls forever instead of playing.

Adds a parseRangeHeader helper that parses a single Range: bytes=start-end header (including open-ended and suffix forms, e.g. bytes=500-, bytes=-500), the only form clients like AVPlayer send.

When a valid Range header is present, the route now reads only the requested byte span from the blob store, responds 206 Partial Content with Content-Range and Content-Length, and always advertises Accept-Ranges: bytes. Full responses now also get an explicit Content-Length.

Threads start/length through to blobStore.createReadStreamFromEntry, which already forwarded its options straight to Hyperblobs' createReadStream — just needed the JSDoc updated to declare the two new option fields.
A missing/malformed/unsatisfiable Range header falls back to serving the full resource, matching standard HTTP semantics.